### PR TITLE
fix: 공개 라우트는 부트스트랩 게이트 우회해 회원가입 흐름 차단 해소

### DIFF
--- a/src/components/AuthBootstrapGate.tsx
+++ b/src/components/AuthBootstrapGate.tsx
@@ -3,7 +3,12 @@ import { useAuthBootstrap } from "../hooks/useAuthBootstrap";
 import { useUserStore } from "../stores/useUserStore";
 import LoadingSpinner from "./LoadingSpinner";
 
-const BYPASS_PATHS = new Set(["/auth/callback"]);
+const BYPASS_PATHS = new Set([
+  "/auth/callback",
+  "/landing",
+  "/login",
+  "/login-landing",
+]);
 
 export default function AuthBootstrapGate({
   children,


### PR DESCRIPTION
## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

- 앱 진입 시 refresh 쿠키로 access 토큰을 자동 재발급하는 부트스트랩 훅(useAuthBootstrap) 추가
- 부트스트랩 결과를 기다리는 동안 보호 라우트 진입을 보류하는 AuthBootstrapGate 추가 — refresh 응답 전에 ProtectedRoute가 /landing으로 튕기던 문제 해결
- 유저 스토어에 부트스트랩 상태 필드(pending | authed | guest) 추가
- 자동 로그인 성공 시 내 프로필도 함께 prefetch 하여 첫 화면 깜빡임 제거
- StrictMode 이중 호출에서 cancelled 플래그에 막혀 pending이 영원히 풀리지 않던 race condition 수정 (모듈 레벨 inflight 플래그로 교체)
- 게이트의 BYPASS_PATHS에 공개 라우트(/landing, /login, /login-landing) 포함 — 신규 회원의 디스코드 콜백 직후 /login 회원가입 화면이 스피너에 가려지던 버그 수정
