### PR TITLE
fix: 홈 일정 목록 하단이 peeking sheet에 가려 잘리는 문제 수정

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -83,7 +83,7 @@ export default function Home() {
     <>
       <TopAppBar />
       <main
-        className={`pt-20 pb-24 px-5 transition-all ${
+        className={`pt-20 pb-32 px-5 transition-all ${
           sheetOpen ? "opacity-30 pointer-events-none blur-[2px]" : ""
         }`}
       >


### PR DESCRIPTION
## Summary
- /home 에서 날짜 선택 시 일정 카드가 많을 때 마지막 카드 하단이 잘려 보이던 문제 수정
- main의 하단 padding을 pb-24(96px) → pb-32(128px) 로 조정

## 원인
main 의 pb-24 = 96px 이지만, 하단 fixed 요소가 더 큰 영역을 가림:
- BottomNav (fixed bottom-0, h-20) → 0~80px
- BottomSheet peeking (fixed bottom-20, h-8) → 80~112px

총 112px 가림 영역이 96px padding 보다 커서, 스크롤 끝까지 내려도 마지막 카드 아래쪽 약 16px 가 peeking sheet 에 가려졌음.

## 수정
pb-32 (128px) 로 변경하여 112px 가림 영역 + 16px 여유 확보.

## Test plan
- [ ] /home 에서 행사 많은 날짜 클릭 후 스크롤 끝까지 내려 마지막 카드 확인
- [ ] 행사 1~2개인 날짜 레이아웃 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 홈 페이지의 하단 여백 크기가 조정되어 레이아웃이 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Q-Check23/FrontEnd/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->