### PR TITLE
fix: 홈 검색 시트 검색 결과까지 가나다순 정렬 통합

### DIFF
--- a/src/pages/Home/components/BottomSheet.tsx
+++ b/src/pages/Home/components/BottomSheet.tsx
@@ -36,15 +36,14 @@ export default function BottomSheet({
   const { data: filterResults = [] } = useCalendarFilter(filterParams, open && !hasQuery);
   const { data: clubs = [] } = useMyClubs();
 
-  const sortedFilterResults = useMemo(
+  const rawResults = hasQuery ? searchResults : filterResults;
+  const results = useMemo(
     () =>
-      [...filterResults].sort((a, b) =>
+      [...rawResults].sort((a, b) =>
         a.eventTitle.localeCompare(b.eventTitle, "ko"),
       ),
-    [filterResults],
+    [rawResults],
   );
-
-  const results = hasQuery ? searchResults : sortedFilterResults;
   const isDefaultMode = !hasQuery && !startDate && !endDate && !selectedClub;
 
   const handleTogglePeriod = useCallback(() => {


### PR DESCRIPTION
기존엔 기본 모드 결과만 가나다순으로 정렬했는데, 검색 모드 결과도 같은
방식으로 정렬되도록 통합. 백엔드가 소속 클럽 전체 이벤트를 내려주게
바뀌면서 더 많은 이벤트가 들어와 정렬 일관성이 중요해졌음.

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #4 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

-
-
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] 💄 Style - UI/스타일 변경
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 📸 스크린샷

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

| Before | After |
|--------|-------|
|        |       |

---

## 🧪 테스트

### 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 성공
- [ ] 로컬에서 테스트 완료
- [ ] 반응형 (모바일/데스크톱) 확인
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

1. 
2. 
3. 

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 이벤트 목록의 정렬 방식이 통일되었습니다. 검색 여부와 관계없이 일관된 순서로 표시됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Q-Check23/FrontEnd/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->