### PR TITLE
feat: 모임 설정에 OWNER 전용 모임 삭제 버튼 추가

### DIFF
--- a/src/pages/ClubSettings/ClubSettings.tsx
+++ b/src/pages/ClubSettings/ClubSettings.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import BackHeader from "../../components/BackHeader";
-import { useClubDetail, useUpdateClub, useDiscordBotInviteUrl } from "../../hooks";
+import {
+  useClubDetail,
+  useUpdateClub,
+  useDeleteClub,
+  useDiscordBotInviteUrl,
+} from "../../hooks";
 import { useToastStore } from "../../stores/useToastStore";
 
 export default function ClubSettings() {
@@ -13,6 +18,8 @@ export default function ClubSettings() {
   const { data: club, isLoading } = useClubDetail(clubId);
   const { data: botInviteUrl } = useDiscordBotInviteUrl();
   const mutation = useUpdateClub(clubId);
+  const deleteMutation = useDeleteClub();
+  const isOwner = club?.myRole === "OWNER";
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -31,6 +38,27 @@ export default function ClubSettings() {
     (name.trim() !== club.clubName ||
       description.trim() !== club.clubDescription ||
       discordGuildId.trim() !== (club.discordGuildId ?? ""));
+
+  function handleDelete() {
+    if (
+      !window.confirm(
+        "모임을 정말 삭제하시겠어요? 행사·공지·멤버를 먼저 모두 정리해야 삭제할 수 있어요.",
+      )
+    ) {
+      return;
+    }
+    deleteMutation.mutate(clubId, {
+      onSuccess: () => {
+        pushToast("모임을 삭제했어요");
+        navigate("/dashboard", { replace: true });
+      },
+      onError: (error) => {
+        pushToast(
+          error instanceof Error ? error.message : "삭제에 실패했어요",
+        );
+      },
+    });
+  }
 
   function handleSave() {
     if (!hasChanges) return;
@@ -123,7 +151,7 @@ export default function ClubSettings() {
         </section>
       </main>
 
-      <div className="fixed bottom-0 left-0 w-full p-5 bg-surface/70 backdrop-blur-xl z-50">
+      <div className="fixed bottom-0 left-0 w-full p-5 bg-surface/70 backdrop-blur-xl z-50 space-y-3">
         <button
           onClick={handleSave}
           disabled={!hasChanges || mutation.isPending || !name.trim()}
@@ -131,6 +159,15 @@ export default function ClubSettings() {
         >
           {mutation.isPending ? "저장 중..." : "저장하기"}
         </button>
+        {isOwner && (
+          <button
+            onClick={handleDelete}
+            disabled={deleteMutation.isPending}
+            className="w-full border-2 border-red-500 text-red-500 py-3 rounded-xl text-base font-semibold active:scale-[0.98] transition-transform disabled:opacity-50"
+          >
+            {deleteMutation.isPending ? "삭제 중..." : "모임 삭제"}
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
행사 삭제는 EditEvent 에 이미 있었으나 모임 삭제 UI 만 빠져있던 부분 보강.
useDeleteClub 훅을 연결하고, club.myRole === 'OWNER' 일 때만 빨간 외곽선 '모임 삭제' 버튼 노출. 확인 다이얼로그 + 성공 시 토스트 + /dashboard 로
교체 이동(스테일 디테일 복귀 방지). 백엔드 409(행사·공지·멤버 잔존)는
에러 토스트로 그대로 노출.

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #4 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

-
-
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] 💄 Style - UI/스타일 변경
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 📸 스크린샷

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

| Before | After |
|--------|-------|
|        |       |

---

## 🧪 테스트

### 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 성공
- [ ] 로컬에서 테스트 완료
- [ ] 반응형 (모바일/데스크톱) 확인
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

1. 
2. 
3. 

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->
