### PR TITLE
feat: 대시보드 행사 정보 섹션 정리 — 단일 수정 아이콘 + 삭제 버튼 추가

### DIFF
--- a/src/pages/DashBoard/DashBoard.tsx
+++ b/src/pages/DashBoard/DashBoard.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { useEventDetail, useEventRegistrations } from "../../hooks";
+import { useDeleteEvent, useEventDetail, useEventRegistrations } from "../../hooks";
+import { useToastStore } from "../../stores/useToastStore";
 import EventManageHeader from "../../components/EventManageHeader";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import ErrorFallback from "../../components/ErrorFallback";
@@ -7,9 +8,24 @@ import ErrorFallback from "../../components/ErrorFallback";
 export default function DashBoard() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const pushToast = useToastStore((state) => state.push);
   const eventId = Number(searchParams.get("eventId"));
   const { data: event, isLoading, isError, refetch } = useEventDetail(eventId);
   const { data: registrations = [] } = useEventRegistrations(eventId);
+  const deleteMutation = useDeleteEvent();
+
+  function handleDelete() {
+    if (!window.confirm("정말 이 행사를 삭제하시겠습니까?")) return;
+    deleteMutation.mutate(eventId, {
+      onSuccess: () => {
+        pushToast("행사를 삭제했어요");
+        navigate(-1);
+      },
+      onError: (error) => {
+        pushToast(error instanceof Error ? error.message : "삭제에 실패했어요");
+      },
+    });
+  }
 
   const checkedInCount = registrations.filter(
     (r) => r.status === "CHECKED_IN",
@@ -104,34 +120,40 @@ export default function DashBoard() {
 
         {/* 행사 정보 */}
         <section className="space-y-3">
-          <h3 className="text-xl font-semibold px-1">행사 정보 확인 및 수정</h3>
-          <div className="bg-surface-container-lowest rounded-xl shadow-[0px_4px_20px_rgba(0,0,0,0.04)] overflow-hidden border border-outline-variant/20">
-            <InfoRow
-              label="설명:"
-              value={event?.title ?? "-"}
-              icon="edit"
+          <div className="flex items-center justify-between px-1">
+            <h3 className="text-xl font-semibold">행사 정보 확인 및 수정</h3>
+            <button
               onClick={() => navigate(`/edit-event?eventId=${eventId}`)}
-            />
+              className="material-symbols-outlined text-outline text-[22px] active:scale-95 transition-transform"
+              aria-label="행사 정보 수정"
+            >
+              edit
+            </button>
+          </div>
+          <div className="bg-surface-container-lowest rounded-xl shadow-[0px_4px_20px_rgba(0,0,0,0.04)] overflow-hidden border border-outline-variant/20">
+            <InfoRow label="설명:" value={event?.title ?? "-"} />
             <InfoRow
               label="장소:"
               value={event?.location ?? "-"}
-              icon="edit"
               valueIcon="location_on"
-              onClick={() => navigate(`/edit-event?eventId=${eventId}`)}
             />
             <InfoRow
               label="시간:"
               value={event?.startTime ? formatDateTime(event.startTime) : "-"}
-              icon="edit"
-              onClick={() => navigate(`/edit-event?eventId=${eventId}`)}
             />
             <InfoRow
               label="인원 수:"
               value={`${registrations.length}명`}
-              icon="group"
               isLast
             />
           </div>
+          <button
+            onClick={handleDelete}
+            disabled={deleteMutation.isPending}
+            className="w-full border-2 border-red-500 text-red-500 py-3 rounded-xl text-base font-semibold active:scale-[0.98] transition-transform disabled:opacity-50"
+          >
+            {deleteMutation.isPending ? "삭제 중..." : "행사 삭제"}
+          </button>
         </section>
       </main>
     </div>
@@ -141,17 +163,13 @@ export default function DashBoard() {
 function InfoRow({
   label,
   value,
-  icon,
   valueIcon,
   isLast,
-  onClick,
 }: {
   label: string;
   value: string;
-  icon: string;
   valueIcon?: string;
   isLast?: boolean;
-  onClick?: () => void;
 }) {
   return (
     <div
@@ -170,12 +188,6 @@ function InfoRow({
         )}
         {value}
       </div>
-      <button
-        onClick={onClick}
-        className="material-symbols-outlined text-outline text-[20px] ml-2 active:scale-95 transition-transform"
-      >
-        {icon}
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
설명/장소/시간 각 행마다 같은 수정 화면으로 가는 연필 아이콘이 3개
중복돼 있던 걸 섹션 헤더의 단일 연필로 통합. 카드 아래에는 빨간
'행사 삭제' 버튼을 추가해 EditEvent 까지 들어가지 않아도 바로 삭제
가능하게 함 (useDeleteEvent 재사용, 409 같은 백엔드 에러는 토스트로
노출, 성공 시 navigate(-1) 로 이전 화면 복귀).

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #4 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

-
-
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] 💄 Style - UI/스타일 변경
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 📸 스크린샷

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

| Before | After |
|--------|-------|
|        |       |

---

## 🧪 테스트

### 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 성공
- [ ] 로컬에서 테스트 완료
- [ ] 반응형 (모바일/데스크톱) 확인
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

1. 
2. 
3. 

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->
