### PR TITLE
fix: 사전 등록 QR 코드가 등록 URL 을 인코딩하도록 변경

### DIFF
--- a/src/pages/QRInfo/QRInfo.tsx
+++ b/src/pages/QRInfo/QRInfo.tsx
@@ -9,8 +9,6 @@ export default function QRInfo() {
 
   const qrRef = useRef<HTMLDivElement>(null);
 
-  const checkInQrValue = `QCHECK:CHECKIN:${eventId ?? ""}`;
-  // 사전 등록 링크는 별도 유지
   const registrationLink = `https://qcheck.asia/register?eventId=${eventId ?? ""}`;
 
   function handleCopyLink() {
@@ -90,7 +88,7 @@ export default function QRInfo() {
             {/* QR 코드 영역 */}
             <div ref={qrRef} className="relative w-64 h-64 bg-white p-4 rounded-xl shadow-inner flex items-center justify-center">
               <QRCodeSVG
-                value={checkInQrValue}
+                value={registrationLink}
                 size={224}
                 level="M"
               />


### PR DESCRIPTION
기존엔 사전 등록 QR 의 value 로 내부 체크인 토큰
(QCHECK:CHECKIN:{eventId}) 을 사용하고 있어서 일반 카메라로 스캔해도 URL 이 아니라 처리할 데이터가 없었음.

QR value 를 registrationLink(https://qcheck.asia/register?eventId=...) 로 교체. 이 페이지에서 더 이상 사용되지 않는 checkInQrValue 변수
제거.

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #4 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

-
-
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] 💄 Style - UI/스타일 변경
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 📸 스크린샷

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

| Before | After |
|--------|-------|
|        |       |

---

## 🧪 테스트

### 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 성공
- [ ] 로컬에서 테스트 완료
- [ ] 반응형 (모바일/데스크톱) 확인
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

1. 
2. 
3. 

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->
