### PR TITLE
refactor: 탭 제거 및 행사 중심 구조로 모임 상세 페이지 개편

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ import Login from "./pages/Login/Login"
 import Home from "./pages/Home/Home"
 import Meeting from "./pages/Meetings/Meetings"
 import Profile from "./pages/Profile/ProfilePage"
-import GroupNotice from "./pages/GroupNotice/GroupNotice";
 import GroupEvents from "./pages/GroupEvents/GroupEvents";
 import GroupMembers from "./pages/GroupMembers/GroupMembers";
 import EventInfo from "./pages/EventInfo/EventInfo";
@@ -22,7 +21,6 @@ import CreateEvent from "./pages/CreateEvent/CreateEvent";
 import CreateClub from "./pages/CreateClub/CreateClub";
 import EditEvent from "./pages/EditEvent/EditEvent";
 import ClubSettings from "./pages/ClubSettings/ClubSettings";
-import NoticeDetail from "./pages/NoticeDetail/NoticeDetail";
 import ProfileSettings from "./pages/Profile/ProfileSettings";
 import AuthCallback from "./pages/AuthCallback/AuthCallback";
 import Register from "./pages/Register/Register";
@@ -51,8 +49,6 @@ export default function App() {
             <Route element={<ProtectedRoute />}>
               <Route path="/dashboard" element={<DashBoard/>} />
               <Route path="/qr-info" element={<QRInfo/>} />
-              <Route path="/group-notice" element={<GroupNotice />} />
-              <Route path="/notice-detail" element={<NoticeDetail />} />
               <Route path="/group-events" element={<GroupEvents />} />
               <Route path="/group-members" element={<GroupMembers />} />
               <Route path="/event-info" element={<EventInfo />} />

--- a/src/pages/GroupEvents/GroupEvents.tsx
+++ b/src/pages/GroupEvents/GroupEvents.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useClubMembers, useDiscordBotInviteUrl, useEvents, useMyClubs } from "../../hooks";
 import BackHeader from "../../components/BackHeader";
-import GroupTabs from "../../components/GroupTabs";
 import EventCard from "./components/EventCard";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import ErrorFallback from "../../components/ErrorFallback";
@@ -39,18 +38,24 @@ export default function GroupEvents() {
         subtitle={`멤버 ${memberCount}명`}
         backTo="/meeting"
         rightSlot={
-          isAdmin ? (
+          <div className="flex items-center gap-1">
             <button
-              onClick={() => navigate(`/club-settings?clubId=${clubId}`)}
+              onClick={() => navigate(`/group-members?clubId=${clubId}&role=${role}`)}
               className="material-symbols-outlined text-on-surface-variant p-1 active:scale-95 transition-transform"
             >
-              settings
+              group
             </button>
-          ) : undefined
+            {isAdmin && (
+              <button
+                onClick={() => navigate(`/club-settings?clubId=${clubId}`)}
+                className="material-symbols-outlined text-on-surface-variant p-1 active:scale-95 transition-transform"
+              >
+                settings
+              </button>
+            )}
+          </div>
         }
       />
-      <GroupTabs activeTab="events" />
-
       <main className="p-5 pb-32">
         {/* 디스코드 봇 연동 배너 (관리자 전용) */}
         {isAdmin && botInviteUrl && (

--- a/src/pages/GroupMembers/GroupMembers.tsx
+++ b/src/pages/GroupMembers/GroupMembers.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import BackHeader from "../../components/BackHeader";
-import GroupTabs from "../../components/GroupTabs";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import ErrorFallback from "../../components/ErrorFallback";
 import MemberCard from "./components/MemberCard";
@@ -129,7 +128,7 @@ export default function GroupMembers() {
       <BackHeader
         title={clubName}
         subtitle={`멤버 ${members.length}명`}
-        backTo="/meeting"
+        backTo={`/group-events?clubId=${clubId}&role=${role}`}
         rightSlot={
           isAdmin ? (
             <button
@@ -141,8 +140,6 @@ export default function GroupMembers() {
           ) : undefined
         }
       />
-      <GroupTabs activeTab="members" />
-
       <main className="pb-24">
         {/* 검색 & 필터 */}
         <div className="px-5 pt-6 pb-2 flex items-center justify-between">

--- a/src/pages/Meetings/Meetings.tsx
+++ b/src/pages/Meetings/Meetings.tsx
@@ -78,7 +78,7 @@ export default function Meeting() {
                 key={club.clubId}
                 club={club}
                 onClick={() =>
-                  navigate(`/group-notice?clubId=${club.clubId}&role=${club.myRole}`)
+                  navigate(`/group-events?clubId=${club.clubId}&role=${club.myRole}`)
                 }
               />
             ))


### PR DESCRIPTION
모임 진입 시 공지 탭을 거치지 않고 행사 페이지로 바로 이동하도록 변경하고,
멤버 접근은 상단바 아이콘으로 이동하여 탭바를 완전히 제거

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #4 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

- 모임 상세 탭바 제거
- 공지 제거
- 멤버 상단바로 이동
