### PR TITLE
fix: 마이페이지 연락처 정렬과 활동 통계 응답 매핑 보정

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -60,10 +60,20 @@ export interface MyUserStats {
   upcoming: number;
 }
 
-export async function getMyStats() {
-  return apiRequest<MyUserStats>("/users/me/stats", {
+interface MyUserStatsResponse {
+  attendedEventCount: number;
+  upcomingEventCount: number;
+}
+
+export async function getMyStats(): Promise<MyUserStats> {
+  const response = await apiRequest<MyUserStatsResponse>("/users/me/stats", {
     method: "GET",
     auth: { type: "dev-user" },
   });
+
+  return {
+    attended: response.attendedEventCount,
+    upcoming: response.upcomingEventCount,
+  };
 }
 

--- a/src/pages/Profile/ProfilePage.tsx
+++ b/src/pages/Profile/ProfilePage.tsx
@@ -90,23 +90,19 @@ export default function ProfilePage() {
         {/* 연락처 정보 */}
         <section className="bg-surface-container-lowest rounded-xl p-5 shadow-[0px_4px_20px_0px_rgba(0,0,0,0.04)] flex flex-col gap-4">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0">
               <span className="material-symbols-outlined text-primary">mail</span>
             </div>
-            <div className="flex flex-col">
-              <p className="text-xs font-semibold text-on-surface-variant">이메일</p>
-              <p className="text-base font-medium">{profile?.email || "-"}</p>
-            </div>
+            <p className="text-xs font-semibold text-on-surface-variant flex-shrink-0">이메일</p>
+            <p className="text-base font-medium truncate">{profile?.email || "-"}</p>
           </div>
           <div className="h-px bg-outline-variant/30 w-full" />
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-tertiary/10 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-full bg-tertiary/10 flex items-center justify-center flex-shrink-0">
               <span className="material-symbols-outlined text-tertiary">call</span>
             </div>
-            <div className="flex flex-col">
-              <p className="text-xs font-semibold text-on-surface-variant">휴대폰 번호</p>
-              <p className="text-base font-medium">{profile?.phone || "-"}</p>
-            </div>
+            <p className="text-xs font-semibold text-on-surface-variant flex-shrink-0">휴대폰 번호</p>
+            <p className="text-base font-medium truncate">{profile?.phone || "-"}</p>
           </div>
         </section>
 


### PR DESCRIPTION


## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #4 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

- 이메일/휴대폰 라벨과 값을 한 줄로 좌측 정렬하고 긴 값은 truncate
- /users/me/stats 응답의 attendedEventCount/upcomingEventCount 필드를 프론트 모델(attended/upcoming)로 매핑해 참여한/예정된 행사 수 연동 복구
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] 💄 Style - UI/스타일 변경
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 📸 스크린샷

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

| Before | After |
|--------|-------|
|        |       |

---

## 🧪 테스트

### 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 성공
- [ ] 로컬에서 테스트 완료
- [ ] 반응형 (모바일/데스크톱) 확인
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

1. 
2. 
3. 

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->
