### PR TITLE
fix/ui: QR 체크인 플로우 및 UI/연동 보정

### DIFF
--- a/docs/dto-mismatch-report.md
+++ b/docs/dto-mismatch-report.md
@@ -1,0 +1,60 @@
+# 백엔드 ↔ 프론트엔드 DTO 불일치 정리
+
+작성일: 2026-05-29
+
+QCheck_Backend(Spring, Java record DTO)와 QCheck_Frontend(`src/api/*.ts`) 간 DTO를
+도메인별로 대조한 결과. 양쪽 모두 camelCase JSON 직렬화를 사용한다.
+
+> 현재 동작에 치명적 장애는 없어 즉시 수정 없이 기록만 남긴다. 추후 정리 시 참고.
+
+## 🔴 런타임 버그로 이어지는 불일치
+
+### 1. Event — `endTime` / `registerFee` 가 프론트에 통째로 누락
+백엔드 event DTO 전반에 `endTime`(String), `registerFee`(BigDecimal)가 존재하나
+프론트 `src/api/events.ts` 어디에도 정의가 없다.
+
+| 백엔드 DTO | 프론트 타입 | 누락 필드 |
+|---|---|---|
+| `CreateEventRequestDto` | `CreateEventRequest` | `endTime`, `registerFee` |
+| `UpdateEventRequestDto` | `UpdateEventRequest` | `endTime`, `registerFee` |
+| `EventDetailResponseDto` | `EventDetail` / `EventDetailResponse` | `endTime`, `registerFee` |
+| `EventListItemDto` | `EventSummary` / `EventSummaryResponse` | `endTime`, `registerFee` |
+
+영향: 행사 생성/수정 시 종료시간·참가비가 전송되지 않고, 상세/목록에서도 표시 불가.
+
+### 2. Club 생성 응답 — 필드명이 전부 다름 (값이 `undefined`)
+`POST /clubs` 백엔드는 `MyClubResponseDto`를 반환하는데 프론트는 `ClubResponse`로 타이핑됨.
+
+```
+BE 응답:  { clubId, clubName, clubDescription, myRole }   (MyClubResponseDto)
+FE 타입:  { id, name, description }                        (ClubResponse, src/api/clubs.ts:42)
+```
+
+영향: `createClub()` 결과의 `.id` / `.name` / `.description` 은 런타임에 전부 `undefined`.
+필드명을 `clubId/clubName/clubDescription`로 맞추고 `myRole` 추가 필요.
+(`getMyClubs`/`getClubDetail`는 올바른 이름을 사용 중 — `createClub`만 어긋남)
+
+## 🟡 누락된 연동 (백엔드만 존재)
+
+- **Settlement 도메인 전체 미연동** — 백엔드에 컨트롤러 + DTO 5종
+  (`CreateSettlementRequestDto`, `SettlementResponseDto`, `SettlementSummaryDto`,
+  `SettlementItemResponseDto`, `SettlementGroupRequestDto`)이 있으나 프론트에 관련 코드 0건.
+- **`POST /clubs/join`** (초대코드 가입, `JoinClubRequestDto.inviteCode`) — 프론트 미구현.
+  (프론트 `joinClubViaEvent`는 별개 엔드포인트 `/join-via-event/{eventId}`로 정상 동작)
+- **`GET /clubs/{clubId}/invite-code`** — 프론트 미구현.
+
+## 🟢 경미 (동작엔 문제없으나 정리 권장)
+
+- `UpdateClubRequest`(FE) 전 필드 optional ↔ `UpdateClubRequestDto`(BE) 전 필드 필수.
+  PUT 전체 교체 의미상, 일부 필드만 보내면 BE에서 누락 필드가 null이 될 수 있음.
+- Notice: `createNotice` FE 응답 타입이 `{ noticeId }`뿐, `updateNotice`는 `void`지만
+  BE는 둘 다 전체 `NoticeResponseDto` 반환 (FE가 나머지 필드를 버릴 뿐, 깨지진 않음).
+- Club `addClubMember` / `updateClubMemberRole`: FE `void` ↔ BE `ClubMemberResponseDto` 반환 (응답 무시).
+- 방어적 nullable 차이: `MyProfileResponse`, `ClubDetailResponse.discordGuildId`, 캘린더 필드 —
+  BE는 non-null 선언이나 FE가 `string | null`로 받아 정규화. 버그 아님.
+
+## 일치 확인된 영역
+
+- identity(auth/user): 모든 요청/응답 필드 일치 (방어적 nullable 외)
+- attendance / event registration: 전부 일치
+- discord(`/bot-invite-url`): 일치

--- a/docs/qr-checkin-flow.md
+++ b/docs/qr-checkin-flow.md
@@ -1,0 +1,106 @@
+# QR 스캔 → 행사 참여(체크인) 플로우 정리
+
+작성일: 2026-05-29
+
+서비스 외부 기본 카메라 또는 인앱 스캐너로 행사 QR을 스캔했을 때의 처리 흐름과,
+관련 백엔드 제약(상태 전이 규칙)을 정리한다. 구현 코드는 `src/pages/Checkin`,
+`src/components/EventRegistrationForm.tsx`, `src/pages/QRCheckIn`, `src/pages/QRInfo` 참고.
+
+## QR 종류와 라우트 (의도별로 분리)
+
+| 용도 | 인코딩 값 | 진입 라우트 | 처리 |
+|---|---|---|---|
+| 사전 등록 링크(원격 공유) | `https://qcheck.asia/register?eventId=X` | `/register` | 등록만 → 행사 상세 |
+| 체크인 QR(현장 게시) | `https://qcheck.asia/checkin?eventId=X` | `/checkin` | 4단계 → self check-in → 행사 상세 |
+
+`QRInfo.tsx`에서 복사용 링크 텍스트는 `/register`, QR 코드(`QRCodeSVG value`)는 `/checkin`을 인코딩한다.
+
+### `QCHECK:CHECKIN:{id}` vs URL 방식
+- `QCHECK:CHECKIN:{id}`는 앱 내부에서만 의미 있는 자체 문자열. **기본 카메라는 텍스트로만 인식**하여 동작하지 않음.
+- URL 방식은 OS·카메라·메신저가 "열기"로 인식 → 브라우저가 `/checkin`을 열고 `ProtectedRoute`/라우터 흐름을 탐.
+- "외부 기본 카메라 스캔" 요구사항은 **URL 방식만 성립**한다.
+- `QRInfo`는 원래부터 URL을 생성했고, 인앱 스캐너의 `QCHECK:CHECKIN` 파서는 실제 QR과 안 맞는 사실상 죽은 코드였음 → 아래처럼 통일하며 해소.
+
+## 외부 카메라 ↔ 인앱 스캐너 통일
+
+두 경로 모두 `/checkin?eventId=X` **단일 처리 진입점**으로 수렴한다.
+
+```
+외부 기본 카메라 → QR(URL) 스캔 → 브라우저가 /checkin?eventId=X 열기 ┐
+                                                                   ├▶ /checkin
+인앱 스캐너(/qrcheck-in) → QR 스캔 → eventId 추출 → /checkin?eventId=X ┘
+                                                                        │
+                                       모임 가입 → 사전 등록 → self check-in → /event-info
+```
+
+- 인앱 스캐너(`QRCheckIn.tsx`)는 `parseEventIdFromQr()`로 URL에서 `eventId`를 추출하고 `/checkin`으로 `navigate`. (레거시 `QCHECK:CHECKIN:{id}` 포맷은 폴백으로만 인식)
+- `QRCheckIn`의 "참가자 직접 등록"(운영진이 이름/전화로 찾아 `manual` 체크인)은 통일 대상이 아닌 별개 기능으로 유지.
+
+## 4단계 플로우와 호출 API
+
+`/checkin`(`Checkin.tsx`)이 사용자 상태에 따라 분기. 공통 UI(가입 모달 + 등록 폼)는
+`EventRegistrationForm.tsx`로 추출됨. `/register`도 같은 컴포넌트를 사용.
+
+| 케이스 | 상태 | 동작 | 호출 순서 |
+|---|---|---|---|
+| 1 | 미회원 | 로그인/회원가입 후 원래 URL 복귀 | `ProtectedRoute` → `setAuthNext`/`consumeAuthNext` (기존 메커니즘) |
+| 2 | 모임 미가입 | 가입 모달 → 등록 폼 → 체크인 | `POST /clubs/join-via-event/{id}` → `POST /events/{id}/registrations` → `POST /attendance/self-check-in` |
+| 3 | 미등록 | 등록 폼 → 체크인 | `POST /events/{id}/registrations` → `POST /attendance/self-check-in` |
+| 4 | 이미 등록 | 자동 체크인(1회 가드) | `POST /attendance/self-check-in` (이미 `CHECKED_IN`이면 호출 없이 안내만) |
+
+- self check-in 요청 바디: `{ "eventId": <Long> }` (`/api/attendance/self-check-in`). 백엔드가 토큰의 로그인 사용자 + `(eventId, user)` 등록건으로 처리.
+- **시간 게이팅 없음**: self check-in 서비스 로직에 행사 시작 시각 기준 제한이 없어 등록만 되어 있으면 언제든 체크인 가능. (프론트 `EventInfo.tsx`의 30분 컷오프는 버튼 노출용 UI 로직일 뿐)
+- 체크인 실패 시에도 등록은 유지되므로 에러 토스트 후 `/event-info`로 이동(상세에서 상태 확인/재시도 가능).
+
+## 등록 상태 머신 (백엔드 제약)
+
+`RegistrationStatus`: `REGISTERED`, `CANCELED`, `CHECKED_IN`. 상태 전이는 백엔드 3곳에서만 발생.
+
+```
+REGISTERED ──check-in──▶ CHECKED_IN   (종착, 빠져나갈 수 없음)
+REGISTERED ──cancel────▶ CANCELED      (행사 시작 전 & REGISTERED 일 때만)
+CHECKED_IN ──▶ ✗                       (해제/취소/되돌리기 엔드포인트 없음)
+CANCELED   ──▶ ✗                       (재등록도 막힘 — 아래 참고)
+```
+
+| 전이 | 위치 |
+|---|---|
+| → `CHECKED_IN` | `AttendanceService.java:76, 125` (check-in / self / manual) |
+| → `CANCELED` | `RegistrationService.java:116` (`cancelMyRegistration`) |
+
+체크인 취소 시도는 `cancelMyRegistration`이 막는다:
+```java
+if (registration.getStatus() == RegistrationStatus.CHECKED_IN)
+    throw new AppException(ErrorCode.CONFLICT, "Cannot cancel a checked-in registration");
+```
+프론트 `EventInfo.tsx`도 `isCheckedIn`이면 "입장 완료"만 표시하고 불참·등록취소 버튼을 숨겨 일관됨.
+
+## 알려진 빈틈 (백엔드 정책 결정 사항, 미수정)
+
+### 1. CANCELED → 재등록 차단 (QR 재스캔 시 막다른 길)
+`RegistrationService.createRegistration`의 중복 체크가 **status 무관**으로 동작하고,
+취소는 행을 삭제하지 않고 상태만 바꾸므로 CANCELED 행이 남아 재등록을 막는다.
+```java
+// RegistrationService.java:70
+if (registrationRepository.existsByEvent_IdAndUser_Id(eventId, currentUserId))
+    throw new AppException(ErrorCode.CONFLICT, "Already registered for this event");
+```
+영향: 취소한 사용자가 체크인 QR을 다시 스캔하면 프론트는 미등록으로 보고 폼을 띄우지만,
+제출 시 409로 실패. 재참여 불가.
+해결안: `createRegistration`에서 기존 행이 CANCELED면 throw 대신 `REGISTERED`로 되살리기(권장),
+또는 별도 재활성화 엔드포인트.
+
+### 2. 체크인 실수 정정 불가
+`CHECKED_IN`을 되돌리는 경로가 본인·운영진 모두 없다(`CHECKED_IN → REGISTERED`/해제 엔드포인트 부재).
+의도된 정책이면 유지, 정정이 필요하면 운영진용 체크인 해제 엔드포인트 추가 필요.
+
+## 이번 작업으로 변경된 파일 (프론트)
+
+| 파일 | 변경 |
+|---|---|
+| `src/components/EventRegistrationForm.tsx` | 신규. 가입 모달 + 등록 폼 공용 컴포넌트 |
+| `src/pages/Checkin/Checkin.tsx` | 신규. 4단계 → self check-in → `/event-info` |
+| `src/pages/Register/Register.tsx` | 공용 컴포넌트 사용 + 제출 후 `/qr-info`(운영진 전용, 버그) → `/event-info` 수정 |
+| `src/pages/QRCheckIn/QRCheckIn.tsx` | 스캔 시 `/checkin`으로 위임(통일). 자체 self check-in/에러 모달 제거, 운영진 직접 등록 유지 |
+| `src/pages/QRInfo/QRInfo.tsx` | QR 코드 인코딩을 `/checkin?eventId=`로 분리(복사용 링크 텍스트는 `/register` 유지) |
+| `src/App.tsx` | `/checkin` 라우트 추가(ProtectedRoute 하위) |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import ClubSettings from "./pages/ClubSettings/ClubSettings";
 import ProfileSettings from "./pages/Profile/ProfileSettings";
 import AuthCallback from "./pages/AuthCallback/AuthCallback";
 import Register from "./pages/Register/Register";
+import Checkin from "./pages/Checkin/Checkin";
 
 import Layout from "./components/Layout"
 import ProtectedRoute from "./components/ProtectedRoute"
@@ -48,6 +49,7 @@ export default function App() {
             {/* 보호 라우트 */}
             <Route element={<ProtectedRoute />}>
               <Route path="/register" element={<Register />} />
+              <Route path="/checkin" element={<Checkin />} />
               <Route path="/group-events" element={<GroupEvents />} />
               <Route path="/group-members" element={<GroupMembers />} />
               <Route path="/event-info" element={<EventInfo />} />

--- a/src/api/clubs.ts
+++ b/src/api/clubs.ts
@@ -122,6 +122,18 @@ export function joinClubViaEvent(eventId: number) {
   });
 }
 
+export interface AddClubMemberRequest {
+  userId: number;
+}
+
+export function addClubMember(clubId: number, body: AddClubMemberRequest) {
+  return apiRequest<void>(`/clubs/${clubId}/members`, {
+    method: "POST",
+    auth: { type: "dev-user" },
+    body,
+  });
+}
+
 export function updateClubMemberRole(
   clubId: number,
   memberId: number,

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -77,3 +77,25 @@ export async function getMyStats(): Promise<MyUserStats> {
   };
 }
 
+export interface UserSearchResult {
+  userId: number;
+  username: string;
+  realName: string | null;
+}
+
+export interface SearchUsersParams {
+  username?: string;
+  email?: string;
+}
+
+export function searchUsers(params: SearchUsersParams) {
+  return apiRequest<UserSearchResult[]>("/users/search", {
+    method: "GET",
+    auth: { type: "dev-user" },
+    query: {
+      username: params.username,
+      email: params.email,
+    },
+  });
+}
+

--- a/src/components/EventRegistrationForm.tsx
+++ b/src/components/EventRegistrationForm.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useJoinClubViaEvent, useMyClubs } from "../hooks";
+import { useToastStore } from "../stores/useToastStore";
+import type { EventDetail } from "../api/events";
+
+interface EventRegistrationFormProps {
+  event: EventDetail;
+  submitLabel: string;
+  submitting: boolean;
+  onSubmit: (answers: Array<{ fieldId: number; value: string }>) => void;
+  onCancel?: () => void;
+}
+
+export default function EventRegistrationForm({
+  event,
+  submitLabel,
+  submitting,
+  onSubmit,
+  onCancel,
+}: EventRegistrationFormProps) {
+  const navigate = useNavigate();
+  const pushToast = useToastStore((state) => state.push);
+  const { data: myClubs = [], isLoading: clubsLoading } = useMyClubs();
+  const joinMutation = useJoinClubViaEvent();
+  const [joinedNow, setJoinedNow] = useState(false);
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+
+  const isMember = myClubs.some((club) => club.clubId === event.clubId);
+  const needsJoinPrompt = !clubsLoading && !isMember && !joinedNow;
+
+  function handleConfirmJoin() {
+    joinMutation.mutate(event.eventId, {
+      onSuccess: () => {
+        setJoinedNow(true);
+        pushToast("모임에 가입되었어요");
+      },
+      onError: (error) => {
+        pushToast(error instanceof Error ? error.message : "가입에 실패했어요");
+      },
+    });
+  }
+
+  function handleChange(fieldId: number, value: string) {
+    setAnswers((prev) => ({ ...prev, [fieldId]: value }));
+  }
+
+  function handleSubmit() {
+    const payload = event.formFields.map((field) => ({
+      fieldId: field.id,
+      value: answers[field.id] ?? "",
+    }));
+    onSubmit(payload);
+  }
+
+  function handleCancelJoin() {
+    if (onCancel) {
+      onCancel();
+      return;
+    }
+    navigate(-1);
+  }
+
+  return (
+    <>
+      <main className="px-5 py-6 space-y-6">
+        {/* 행사 정보 요약 */}
+        <section className="space-y-3">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary text-[20px]">
+              event_note
+            </span>
+            <h2 className="text-xl font-semibold">행사 정보</h2>
+          </div>
+          <div className="bg-surface-container-lowest p-4 rounded-xl shadow-sm space-y-1">
+            <p className="text-base font-bold">{event.title}</p>
+            <p className="text-sm text-on-surface-variant">
+              {event.location || "장소 미정"}
+            </p>
+          </div>
+        </section>
+
+        {/* 등록 폼 필드 */}
+        <section className="space-y-3">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary text-[20px]">
+              assignment_ind
+            </span>
+            <h2 className="text-xl font-semibold">참가자 정보</h2>
+          </div>
+          <div className="space-y-3">
+            {event.formFields.map((field) => (
+              <div
+                key={field.id}
+                className={`bg-surface-container-lowest p-4 rounded-xl shadow-sm ${
+                  field.required ? "border-l-4 border-primary" : ""
+                }`}
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <label className="text-sm font-semibold text-on-surface">
+                    {field.label}
+                  </label>
+                  <span
+                    className={`text-xs font-semibold px-2 py-1 rounded ${
+                      field.required
+                        ? "text-primary bg-primary/10"
+                        : "text-on-surface-variant bg-surface-container-high"
+                    }`}
+                  >
+                    {field.required ? "필수" : "선택"}
+                  </span>
+                </div>
+                {field.type === "SELECT" ? (
+                  <select
+                    value={answers[field.id] ?? ""}
+                    onChange={(e) => handleChange(field.id, e.target.value)}
+                    className="w-full bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
+                  >
+                    <option value="">선택해주세요</option>
+                    {field.options.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    value={answers[field.id] ?? ""}
+                    onChange={(e) => handleChange(field.id, e.target.value)}
+                    placeholder={`${field.label}을(를) 입력해주세요`}
+                    className="w-full bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      {/* 하단 고정 버튼 */}
+      <div className="fixed bottom-0 left-0 w-full p-5 bg-surface/70 backdrop-blur-xl z-50">
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || needsJoinPrompt}
+          className="w-full bg-gradient-to-br from-primary to-primary-container text-on-primary py-4 rounded-xl text-xl font-semibold shadow-lg active:scale-[0.98] transition-transform disabled:opacity-50"
+        >
+          {submitting ? "처리 중..." : submitLabel}
+        </button>
+      </div>
+
+      {/* 가입 확인 모달 */}
+      {needsJoinPrompt && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center p-5 bg-on-surface/40 backdrop-blur-[2px]">
+          <div className="bg-surface-container-lowest rounded-2xl p-6 max-w-sm w-full text-center shadow-xl border border-outline-variant">
+            <h2 className="text-xl font-bold text-on-surface mb-2">
+              모임에 등록하시겠습니까?
+            </h2>
+            <p className="text-sm text-on-surface-variant mb-6">
+              계속 진행하려면 먼저 이 모임의 멤버가 되어야 합니다.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={handleCancelJoin}
+                disabled={joinMutation.isPending}
+                className="flex-1 border-2 border-outline-variant text-on-surface py-3 rounded-xl text-base font-semibold active:scale-[0.98] transition-transform disabled:opacity-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleConfirmJoin}
+                disabled={joinMutation.isPending}
+                className="flex-1 bg-gradient-to-br from-primary to-primary-container text-on-primary py-3 rounded-xl text-base font-semibold active:scale-[0.98] transition-transform disabled:opacity-50"
+              >
+                {joinMutation.isPending ? "가입 중..." : "확인"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -28,6 +28,7 @@ export { useUpdateProfile } from "./mutations/useUpdateProfile";
 export { useLogout } from "./mutations/useLogout";
 export { useUpdateClubMemberRole } from "./mutations/useUpdateClubMemberRole";
 export { useRemoveClubMember } from "./mutations/useRemoveClubMember";
+export { useAddClubMember } from "./mutations/useAddClubMember";
 export { useLeaveClub } from "./mutations/useLeaveClub";
 export { useJoinClubViaEvent } from "./mutations/useJoinClubViaEvent";
 export { useCreateClub } from "./mutations/useCreateClub";

--- a/src/hooks/mutations/useAddClubMember.ts
+++ b/src/hooks/mutations/useAddClubMember.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { addClubMember, type AddClubMemberRequest } from "../../api/clubs";
+import { queryKeys } from "../keys";
+
+export function useAddClubMember(clubId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: AddClubMemberRequest) => addClubMember(clubId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.clubs.members(clubId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.clubs.detail(clubId),
+      });
+    },
+  });
+}

--- a/src/pages/Checkin/Checkin.tsx
+++ b/src/pages/Checkin/Checkin.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import {
+  useCreateRegistration,
+  useEventDetail,
+  useMyEventRegistration,
+  useSelfCheckIn,
+} from "../../hooks";
+import { useToastStore } from "../../stores/useToastStore";
+import BackHeader from "../../components/BackHeader";
+import LoadingSpinner from "../../components/LoadingSpinner";
+import ErrorFallback from "../../components/ErrorFallback";
+import EventRegistrationForm from "../../components/EventRegistrationForm";
+
+export default function Checkin() {
+  const navigate = useNavigate();
+  const pushToast = useToastStore((state) => state.push);
+  const [searchParams] = useSearchParams();
+  const eventId = Number(searchParams.get("eventId"));
+
+  const { data: event, isLoading, isError, refetch } = useEventDetail(eventId);
+  const { data: myRegistration, isLoading: regLoading } =
+    useMyEventRegistration(eventId);
+  const createMutation = useCreateRegistration(eventId);
+  const selfCheckInMutation = useSelfCheckIn(eventId);
+
+  const isRegistered =
+    myRegistration != null && myRegistration.status !== "CANCELED";
+  const isCheckedIn = myRegistration?.status === "CHECKED_IN";
+
+  const completedRef = useRef(false);
+
+  function completeCheckIn(alreadyCheckedIn: boolean) {
+    const goToDetail = () =>
+      navigate(`/event-info?eventId=${eventId}`, { replace: true });
+
+    if (alreadyCheckedIn) {
+      pushToast("이미 참여 완료된 행사예요");
+      goToDetail();
+      return;
+    }
+
+    selfCheckInMutation.mutate(
+      { eventId },
+      {
+        onSuccess: () => {
+          pushToast("참여가 완료되었어요");
+          goToDetail();
+        },
+        onError: (error) => {
+          // 등록은 유지되므로 상세 페이지에서 상태 확인/재시도 가능
+          pushToast(
+            error instanceof Error ? error.message : "참여 처리에 실패했어요",
+          );
+          goToDetail();
+        },
+      },
+    );
+  }
+
+  // 케이스 4: 이미 사전 등록된 사용자는 곧바로 체크인 처리 (1회만)
+  useEffect(() => {
+    if (regLoading || !isRegistered || completedRef.current) return;
+    completedRef.current = true;
+    completeCheckIn(Boolean(isCheckedIn));
+    // completeCheckIn은 의도적으로 deps에서 제외 (1회 실행 가드)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [regLoading, isRegistered, isCheckedIn]);
+
+  function handleSubmit(answers: Array<{ fieldId: number; value: string }>) {
+    createMutation.mutate(
+      { answers },
+      {
+        onSuccess: () => completeCheckIn(false),
+        onError: (error) => {
+          pushToast(
+            error instanceof Error ? error.message : "등록에 실패했어요",
+          );
+        },
+      },
+    );
+  }
+
+  if (isLoading || regLoading) {
+    return (
+      <div className="bg-surface h-full overflow-y-auto pb-32">
+        <BackHeader title="행사 참여" />
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !event) {
+    return (
+      <div className="bg-surface h-full overflow-y-auto pb-32">
+        <BackHeader title="행사 참여" />
+        <ErrorFallback onRetry={refetch} />
+      </div>
+    );
+  }
+
+  // 이미 등록된 사용자: 체크인 처리 중 화면
+  if (isRegistered) {
+    return (
+      <div className="bg-surface h-full overflow-y-auto pb-32">
+        <BackHeader title="행사 참여" subtitle={event.title} />
+        <div className="flex flex-col items-center justify-center gap-4 px-5 py-20">
+          <LoadingSpinner />
+          <p className="text-sm text-on-surface-variant">참여 처리 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // 케이스 2·3: 미등록 (미가입이면 폼 내부 모달이 가입 처리)
+  return (
+    <div className="bg-surface h-full overflow-y-auto pb-32">
+      <BackHeader title="행사 참여" subtitle={event.title} />
+      <EventRegistrationForm
+        event={event}
+        submitLabel="참여하기"
+        submitting={createMutation.isPending || selfCheckInMutation.isPending}
+        onSubmit={handleSubmit}
+      />
+    </div>
+  );
+}

--- a/src/pages/GroupMembers/GroupMembers.tsx
+++ b/src/pages/GroupMembers/GroupMembers.tsx
@@ -7,7 +7,9 @@ import MemberCard from "./components/MemberCard";
 import MemberActionSheet, {
   type MemberAction,
 } from "./components/MemberActionSheet";
+import AddMemberSheet from "./components/AddMemberSheet";
 import {
+  useAddClubMember,
   useClubMembers,
   useClubRole,
   useLeaveClub,
@@ -18,6 +20,7 @@ import {
 } from "../../hooks";
 import { useToastStore } from "../../stores/useToastStore";
 import type { ClubMember } from "../../api/clubs";
+import type { UserSearchResult } from "../../api/users";
 
 function resolveActions(
   viewerIsAdmin: boolean,
@@ -41,6 +44,7 @@ export default function GroupMembers() {
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<ClubMember | null>(null);
   const [pendingAction, setPendingAction] = useState<MemberAction | null>(null);
+  const [isAddSheetOpen, setAddSheetOpen] = useState(false);
 
   const { data: members = [], isLoading, isError, refetch } = useClubMembers(clubId);
   const { data: clubs = [] } = useMyClubs();
@@ -49,6 +53,19 @@ export default function GroupMembers() {
   const updateRole = useUpdateClubMemberRole(clubId);
   const removeMember = useRemoveClubMember(clubId);
   const leave = useLeaveClub(clubId);
+  const addMember = useAddClubMember(clubId);
+
+  const handleAddMember = async (user: UserSearchResult) => {
+    try {
+      await addMember.mutateAsync({ userId: user.userId });
+      pushToast(`${user.username} 님을 모임에 추가했어요`);
+      setAddSheetOpen(false);
+    } catch (error) {
+      pushToast(
+        error instanceof Error ? error.message : "멤버 추가에 실패했어요",
+      );
+    }
+  };
 
   const currentClub = clubs.find((club) => club.clubId === clubId);
   const clubName = currentClub?.clubName ?? "";
@@ -170,6 +187,29 @@ export default function GroupMembers() {
           )}
         </section>
       </main>
+
+      {/* FAB - 멤버 추가 (운영진 전용) */}
+      {isAdmin && (
+        <button
+          onClick={() => setAddSheetOpen(true)}
+          className="fixed bottom-6 right-6 w-14 h-14 rounded-full bg-gradient-to-br from-primary to-primary-container text-white shadow-lg flex items-center justify-center z-50 active:scale-90 transition-transform"
+        >
+          <span
+            className="material-symbols-outlined text-[28px]"
+            style={{ fontVariationSettings: "'FILL' 1" }}
+          >
+            person_add
+          </span>
+        </button>
+      )}
+
+      <AddMemberSheet
+        open={isAddSheetOpen}
+        existingUserIds={members.map((m) => m.userId)}
+        isAdding={addMember.isPending}
+        onAdd={handleAddMember}
+        onClose={() => setAddSheetOpen(false)}
+      />
 
       <MemberActionSheet
         member={selected}

--- a/src/pages/GroupMembers/components/AddMemberSheet.tsx
+++ b/src/pages/GroupMembers/components/AddMemberSheet.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+import { searchUsers, type UserSearchResult } from "../../../api/users";
+
+interface AddMemberSheetProps {
+  open: boolean;
+  existingUserIds: number[];
+  isAdding: boolean;
+  onAdd: (user: UserSearchResult) => Promise<void> | void;
+  onClose: () => void;
+}
+
+export default function AddMemberSheet({
+  open,
+  existingUserIds,
+  isAdding,
+  onAdd,
+  onClose,
+}: AddMemberSheetProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<UserSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setResults([]);
+      setErrorMessage(null);
+      return;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!open || trimmed.length === 0) {
+      setResults([]);
+      setErrorMessage(null);
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      setIsSearching(true);
+      setErrorMessage(null);
+      try {
+        const data = await searchUsers({ username: trimmed });
+        setResults(data);
+      } catch (error) {
+        setErrorMessage(
+          error instanceof Error ? error.message : "사용자 검색에 실패했어요",
+        );
+      } finally {
+        setIsSearching(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [open, query]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] bg-black/40 flex items-end justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md bg-surface rounded-t-2xl pb-6 pt-3 px-4 max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mx-auto w-10 h-1 bg-outline-variant rounded-full mb-3" />
+        <h3 className="text-lg font-semibold text-on-surface mb-3">멤버 추가</h3>
+
+        <div className="flex items-center gap-2 bg-surface-container-low px-4 py-2 rounded-full mb-3 border border-outline-variant/20">
+          <span className="material-symbols-outlined text-on-surface-variant text-[20px]">
+            search
+          </span>
+          <input
+            autoFocus
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="아이디로 검색"
+            className="bg-transparent border-none focus:outline-none focus:ring-0 text-sm w-full p-0"
+          />
+        </div>
+
+        <ul className="flex-1 overflow-y-auto flex flex-col gap-2">
+          {errorMessage ? (
+            <li className="text-sm text-red-600 py-6 text-center">{errorMessage}</li>
+          ) : isSearching ? (
+            <li className="text-sm text-on-surface-variant py-6 text-center">
+              검색 중...
+            </li>
+          ) : query.trim().length === 0 ? (
+            <li className="text-sm text-on-surface-variant py-6 text-center">
+              아이디를 입력해 사용자를 검색하세요
+            </li>
+          ) : results.length === 0 ? (
+            <li className="text-sm text-on-surface-variant py-6 text-center">
+              검색 결과가 없습니다
+            </li>
+          ) : (
+            results.map((user) => {
+              const alreadyMember = existingUserIds.includes(user.userId);
+              return (
+                <li
+                  key={user.userId}
+                  className="flex items-center gap-3 p-3 rounded-xl bg-surface-container-lowest border border-outline-variant/10"
+                >
+                  <div className="w-10 h-10 rounded-full bg-surface-container-high flex items-center justify-center shrink-0">
+                    <span className="material-symbols-outlined text-on-surface-variant">
+                      person
+                    </span>
+                  </div>
+                  <div className="grow min-w-0">
+                    <p className="text-sm font-semibold text-on-surface truncate">
+                      {user.username}
+                    </p>
+                    {user.realName && (
+                      <p className="text-xs text-on-surface-variant truncate">
+                        {user.realName}
+                      </p>
+                    )}
+                  </div>
+                  <button
+                    disabled={alreadyMember || isAdding}
+                    onClick={() => onAdd(user)}
+                    className="px-3 py-1.5 rounded-full text-xs font-semibold bg-primary text-white disabled:bg-surface-container disabled:text-on-surface-variant active:scale-95 transition-transform"
+                  >
+                    {alreadyMember ? "이미 멤버" : isAdding ? "추가 중..." : "추가"}
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+
+        <button
+          onClick={onClose}
+          disabled={isAdding}
+          className="w-full mt-3 py-3 text-on-surface-variant text-sm font-semibold rounded-xl active:bg-surface-container disabled:opacity-50"
+        >
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/QRCheckIn/QRCheckIn.tsx
+++ b/src/pages/QRCheckIn/QRCheckIn.tsx
@@ -2,10 +2,30 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Html5Qrcode } from "html5-qrcode";
 import { type AttendanceCheckInResult } from "../../api/attendance";
-import { useEventRegistrations, useManualCheckIn, useSelfCheckIn } from "../../hooks";
+import { useEventRegistrations, useManualCheckIn } from "../../hooks";
 import { useToastStore } from "../../stores/useToastStore";
 
-type ScanState = "scanning" | "success" | "error" | "register";
+type ScanState = "scanning" | "success" | "register";
+
+// 체크인 QR에서 eventId 추출.
+// 외부 기본 카메라와 동일한 QR(URL)을 인앱 스캐너도 인식하도록 통일.
+function parseEventIdFromQr(decodedText: string): number | null {
+  // 체크인 QR(URL): https://qcheck.asia/checkin?eventId=123
+  try {
+    const url = new URL(decodedText);
+    const id = Number(url.searchParams.get("eventId"));
+    if (Number.isInteger(id) && id > 0) return id;
+  } catch {
+    // URL이 아니면 레거시 포맷 확인으로 폴백
+  }
+  // 레거시 포맷: QCHECK:CHECKIN:123
+  const match = decodedText.match(/^QCHECK:CHECKIN:(\d+)$/);
+  if (match) {
+    const id = Number(match[1]);
+    if (id > 0) return id;
+  }
+  return null;
+}
 
 export default function QRCheckIn() {
   const navigate = useNavigate();
@@ -15,9 +35,8 @@ export default function QRCheckIn() {
 
   const [state, setState] = useState<ScanState>("scanning");
   const [result, setResult] = useState<AttendanceCheckInResult | null>(null);
-  const [errorMessage, setErrorMessage] = useState("");
 
-  // on-site registration form
+  // on-site registration form (운영진용 직접 등록)
   const [regName, setRegName] = useState("");
   const [regPhone, setRegPhone] = useState("");
 
@@ -25,7 +44,6 @@ export default function QRCheckIn() {
   const processingRef = useRef(false);
   const handleScanRef = useRef<(decodedText: string) => void>(() => {});
 
-  const selfCheckInMutation = useSelfCheckIn(eventId);
   const manualCheckInMutation = useManualCheckIn(eventId);
   const { data: registrations = [] } = useEventRegistrations(eventId);
 
@@ -33,36 +51,22 @@ export default function QRCheckIn() {
     (decodedText: string) => {
       if (processingRef.current) return;
 
-      // QR 포맷 파싱: "QCHECK:CHECKIN:{eventId}"
-      const match = decodedText.match(/^QCHECK:CHECKIN:(\d+)$/);
-      if (!match) {
+      const scannedEventId = parseEventIdFromQr(decodedText);
+      if (!scannedEventId) {
         pushToast("올바른 체크인 QR 코드가 아닙니다.");
         return;
       }
 
-      const scannedEventId = Number(match[1]);
       processingRef.current = true;
 
       // 스캔 성공 시 카메라 일시 정지
       scannerRef.current?.pause(true);
 
-      selfCheckInMutation.mutate(
-        { eventId: scannedEventId },
-        {
-          onSuccess: (data) => {
-            setResult(data);
-            setState("success");
-          },
-          onError: (error) => {
-            setErrorMessage(
-              error instanceof Error ? error.message : "체크인에 실패했어요",
-            );
-            setState("error");
-          },
-        },
-      );
+      // 외부 카메라 스캔과 동일한 처리 경로(/checkin)로 진입.
+      // 모임 가입 / 사전 등록 / 체크인 분기를 /checkin이 일괄 처리.
+      navigate(`/checkin?eventId=${scannedEventId}`);
     },
-    [selfCheckInMutation, pushToast],
+    [navigate, pushToast],
   );
 
   // 최신 handleScan을 ref에 유지 (useEffect 내 stale closure 방지)
@@ -99,7 +103,7 @@ export default function QRCheckIn() {
         .catch(() => {});
       scannerRef.current = null;
     };
-  }, [state]); // handleCheckIn은 의도적으로 제외 (ref 기반 처리)
+  }, [state]); // handleScan은 의도적으로 제외 (ref 기반 처리)
 
   const handleRegisterSubmit = useCallback(() => {
     const name = regName.trim();
@@ -255,7 +259,7 @@ export default function QRCheckIn() {
         <div className="absolute bottom-0 w-full h-48 bg-gradient-to-t from-black/80 to-transparent" />
       </div>
 
-      {/* Success Modal */}
+      {/* Success Modal (운영진 직접 등록 결과) */}
       {state === "success" && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-5 bg-surface/90 backdrop-blur-md">
           <div className="bg-surface-container rounded-2xl p-8 max-w-sm w-full text-center shadow-xl border border-outline-variant">
@@ -280,38 +284,6 @@ export default function QRCheckIn() {
             )}
             <button
               onClick={handleConfirmSuccess}
-              className="w-full py-4 bg-primary text-white rounded-xl text-xl font-semibold active:opacity-70 transition-opacity"
-            >
-              확인
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Error Modal */}
-      {state === "error" && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-5 bg-surface/90 backdrop-blur-md">
-          <div className="bg-surface-container rounded-2xl p-8 max-w-sm w-full text-center shadow-xl border border-outline-variant">
-            <div className="w-20 h-20 bg-error-container rounded-full flex items-center justify-center mx-auto mb-6">
-              <span
-                className="material-symbols-outlined text-on-error-container text-[40px]"
-                style={{ fontVariationSettings: "'FILL' 1" }}
-              >
-                error
-              </span>
-            </div>
-            <h2 className="text-2xl font-bold text-on-surface mb-2">
-              체크인 실패
-            </h2>
-            <p className="text-sm text-on-surface-variant mb-8">
-              {errorMessage}
-            </p>
-            <button
-              onClick={() => {
-                setErrorMessage("");
-                setState("scanning");
-                processingRef.current = false;
-              }}
               className="w-full py-4 bg-primary text-white rounded-xl text-xl font-semibold active:opacity-70 transition-opacity"
             >
               확인

--- a/src/pages/QRInfo/QRInfo.tsx
+++ b/src/pages/QRInfo/QRInfo.tsx
@@ -10,6 +10,7 @@ export default function QRInfo() {
   const qrRef = useRef<HTMLDivElement>(null);
 
   const registrationLink = `https://qcheck.asia/register?eventId=${eventId ?? ""}`;
+  const checkinLink = `https://qcheck.asia/checkin?eventId=${eventId ?? ""}`;
 
   function handleCopyLink() {
     void navigator.clipboard.writeText(registrationLink);
@@ -88,7 +89,7 @@ export default function QRInfo() {
             {/* QR 코드 영역 */}
             <div ref={qrRef} className="relative w-64 h-64 bg-white p-4 rounded-xl shadow-inner flex items-center justify-center">
               <QRCodeSVG
-                value={registrationLink}
+                value={checkinLink}
                 size={224}
                 level="M"
               />

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -1,15 +1,10 @@
-import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import {
-  useCreateRegistration,
-  useEventDetail,
-  useJoinClubViaEvent,
-  useMyClubs,
-} from "../../hooks";
+import { useCreateRegistration, useEventDetail } from "../../hooks";
 import { useToastStore } from "../../stores/useToastStore";
 import BackHeader from "../../components/BackHeader";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import ErrorFallback from "../../components/ErrorFallback";
+import EventRegistrationForm from "../../components/EventRegistrationForm";
 
 export default function Register() {
   const navigate = useNavigate();
@@ -17,47 +12,21 @@ export default function Register() {
   const [searchParams] = useSearchParams();
   const eventId = Number(searchParams.get("eventId"));
   const { data: event, isLoading, isError, refetch } = useEventDetail(eventId);
-  const { data: myClubs = [], isLoading: clubsLoading } = useMyClubs();
   const mutation = useCreateRegistration(eventId);
-  const joinMutation = useJoinClubViaEvent();
-  const [joinedNow, setJoinedNow] = useState(false);
 
-  const [answers, setAnswers] = useState<Record<number, string>>({});
-
-  const isMember = event
-    ? myClubs.some((club) => club.clubId === event.clubId)
-    : false;
-  const needsJoinPrompt =
-    Boolean(event) && !clubsLoading && !isMember && !joinedNow;
-
-  function handleConfirmJoin() {
-    joinMutation.mutate(eventId, {
-      onSuccess: () => {
-        setJoinedNow(true);
-        pushToast("모임에 가입되었어요");
-      },
-      onError: (error) => {
-        pushToast(error instanceof Error ? error.message : "가입에 실패했어요");
-      },
-    });
-  }
-
-  function handleChange(fieldId: number, value: string) {
-    setAnswers((prev) => ({ ...prev, [fieldId]: value }));
-  }
-
-  function handleSubmit() {
-    if (!event) return;
-
-    const payload = event.formFields.map((field) => ({
-      fieldId: field.id,
-      value: answers[field.id] ?? "",
-    }));
-
+  function handleSubmit(answers: Array<{ fieldId: number; value: string }>) {
     mutation.mutate(
-      { answers: payload },
+      { answers },
       {
-        onSuccess: () => navigate(`/qr-info?eventId=${eventId}`),
+        onSuccess: () => {
+          pushToast("사전 등록이 완료되었어요");
+          navigate(`/event-info?eventId=${eventId}`);
+        },
+        onError: (error) => {
+          pushToast(
+            error instanceof Error ? error.message : "등록에 실패했어요",
+          );
+        },
       },
     );
   }
@@ -83,122 +52,12 @@ export default function Register() {
   return (
     <div className="bg-surface h-full overflow-y-auto pb-32">
       <BackHeader title="사전 등록" subtitle={event.title} />
-
-      <main className="px-5 py-6 space-y-6">
-        {/* 행사 정보 요약 */}
-        <section className="space-y-3">
-          <div className="flex items-center gap-2">
-            <span className="material-symbols-outlined text-primary text-[20px]">
-              event_note
-            </span>
-            <h2 className="text-xl font-semibold">행사 정보</h2>
-          </div>
-          <div className="bg-surface-container-lowest p-4 rounded-xl shadow-sm space-y-1">
-            <p className="text-base font-bold">{event.title}</p>
-            <p className="text-sm text-on-surface-variant">
-              {event.location || "장소 미정"}
-            </p>
-          </div>
-        </section>
-
-        {/* 등록 폼 필드 */}
-        <section className="space-y-3">
-          <div className="flex items-center gap-2">
-            <span className="material-symbols-outlined text-primary text-[20px]">
-              assignment_ind
-            </span>
-            <h2 className="text-xl font-semibold">참가자 정보</h2>
-          </div>
-          <div className="space-y-3">
-            {event.formFields.map((field) => (
-              <div
-                key={field.id}
-                className={`bg-surface-container-lowest p-4 rounded-xl shadow-sm ${
-                  field.required ? "border-l-4 border-primary" : ""
-                }`}
-              >
-                <div className="flex items-center justify-between mb-2">
-                  <label className="text-sm font-semibold text-on-surface">
-                    {field.label}
-                  </label>
-                  <span
-                    className={`text-xs font-semibold px-2 py-1 rounded ${
-                      field.required
-                        ? "text-primary bg-primary/10"
-                        : "text-on-surface-variant bg-surface-container-high"
-                    }`}
-                  >
-                    {field.required ? "필수" : "선택"}
-                  </span>
-                </div>
-                {field.type === "SELECT" ? (
-                  <select
-                    value={answers[field.id] ?? ""}
-                    onChange={(e) => handleChange(field.id, e.target.value)}
-                    className="w-full bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
-                  >
-                    <option value="">선택해주세요</option>
-                    {field.options.map((option) => (
-                      <option key={option} value={option}>
-                        {option}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <input
-                    type="text"
-                    value={answers[field.id] ?? ""}
-                    onChange={(e) => handleChange(field.id, e.target.value)}
-                    placeholder={`${field.label}을(를) 입력해주세요`}
-                    className="w-full bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
-                  />
-                )}
-              </div>
-            ))}
-          </div>
-        </section>
-      </main>
-
-      {/* 하단 고정 버튼 */}
-      <div className="fixed bottom-0 left-0 w-full p-5 bg-surface/70 backdrop-blur-xl z-50">
-        <button
-          onClick={handleSubmit}
-          disabled={mutation.isPending || needsJoinPrompt}
-          className="w-full bg-gradient-to-br from-primary to-primary-container text-on-primary py-4 rounded-xl text-xl font-semibold shadow-lg active:scale-[0.98] transition-transform disabled:opacity-50"
-        >
-          {mutation.isPending ? "등록 중..." : "사전 등록하기"}
-        </button>
-      </div>
-
-      {/* 가입 확인 모달 */}
-      {needsJoinPrompt && (
-        <div className="fixed inset-0 z-[60] flex items-center justify-center p-5 bg-on-surface/40 backdrop-blur-[2px]">
-          <div className="bg-surface-container-lowest rounded-2xl p-6 max-w-sm w-full text-center shadow-xl border border-outline-variant">
-            <h2 className="text-xl font-bold text-on-surface mb-2">
-              모임에 등록하시겠습니까?
-            </h2>
-            <p className="text-sm text-on-surface-variant mb-6">
-              사전 등록을 진행하려면 먼저 이 모임의 멤버가 되어야 합니다.
-            </p>
-            <div className="flex gap-3">
-              <button
-                onClick={() => navigate(-1)}
-                disabled={joinMutation.isPending}
-                className="flex-1 border-2 border-outline-variant text-on-surface py-3 rounded-xl text-base font-semibold active:scale-[0.98] transition-transform disabled:opacity-50"
-              >
-                취소
-              </button>
-              <button
-                onClick={handleConfirmJoin}
-                disabled={joinMutation.isPending}
-                className="flex-1 bg-gradient-to-br from-primary to-primary-container text-on-primary py-3 rounded-xl text-base font-semibold active:scale-[0.98] transition-transform disabled:opacity-50"
-              >
-                {joinMutation.isPending ? "가입 중..." : "확인"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <EventRegistrationForm
+        event={event}
+        submitLabel="사전 등록하기"
+        submitting={mutation.isPending}
+        onSubmit={handleSubmit}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 개요
`fix/ui` 브랜치 작업 묶음. 핵심은 **외부 카메라 QR 스캔 기반 행사 참여(체크인) 플로우** 추가이며, 그 외 누적된 UI/연동 보정 커밋을 포함합니다.

## 주요 변경: QR 체크인 플로우
- **`/checkin` 라우트 신설** — 체크인 QR(URL)을 기본 카메라로 스캔하면 사용자 상태에 따라 4케이스 분기:
  1. 미회원 → 로그인/회원가입 후 원래 URL 복귀
  2. 모임 미가입 → 가입 모달 → 등록 폼 → self check-in
  3. 미등록 → 등록 폼 → self check-in
  4. 등록 완료 → 자동 체크인 (이미 체크인 시 안내만)
  → 완료 후 행사 상세(`/event-info`)로 이동
- **공용 컴포넌트 추출** (`EventRegistrationForm`) — 가입 모달 + 등록 폼을 `/register`·`/checkin`에서 공유
- **인앱 스캐너 통일** — 실제 생성되는 QR(URL)을 인식하지 못하던 불일치 해소, 스캔 시 `/checkin`으로 위임해 외부 카메라와 동일 처리
- **QR 인코딩 분리** — 체크인 QR=`/checkin?eventId=`, 사전 등록 링크=`/register?eventId=`
- **버그 수정** — `/register` 제출 후 운영진 전용 `/qr-info`(멤버 튕김) → `/event-info`

## 문서
- `docs/qr-checkin-flow.md` — 플로우, 호출 API, 등록 상태 머신, 알려진 빈틈(CANCELED 재등록 차단·체크인 정정 불가) 정리

## 알려진 빈틈 (백엔드 정책 결정 대기, 본 PR 미포함)
- CANCELED 등록 행이 남아 재등록(409 "Already registered") 차단 → QR 재스캔 시 막다른 길
- `CHECKED_IN` 되돌리기 엔드포인트 부재(실수 정정 불가)

## 검증
- 변경 파일 타입체크 통과 (`npm run typecheck` — 무관한 기존 `useDeleteMyUser.ts` 오류 외 없음)
- 수동 검증 권장: `/checkin?eventId=<유효ID>` 직접 접근으로 4케이스 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)