### PR TITLE
fix: 사전 등록 진입 시 비멤버 클럽 가입 확인 모달 복구

### DIFF
--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -1,5 +1,11 @@
+import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { useCreateRegistration, useEventDetail } from "../../hooks";
+import {
+  useCreateRegistration,
+  useEventDetail,
+  useJoinClubViaEvent,
+  useMyClubs,
+} from "../../hooks";
 import { useToastStore } from "../../stores/useToastStore";
 import BackHeader from "../../components/BackHeader";
 import LoadingSpinner from "../../components/LoadingSpinner";
@@ -12,7 +18,28 @@ export default function Register() {
   const [searchParams] = useSearchParams();
   const eventId = Number(searchParams.get("eventId"));
   const { data: event, isLoading, isError, refetch } = useEventDetail(eventId);
+  const { data: myClubs = [], isLoading: clubsLoading } = useMyClubs();
   const mutation = useCreateRegistration(eventId);
+  const joinMutation = useJoinClubViaEvent();
+  const [joinedNow, setJoinedNow] = useState(false);
+
+  const isMember = event
+    ? myClubs.some((club) => club.clubId === event.clubId)
+    : false;
+  const needsJoinPrompt =
+    Boolean(event) && !clubsLoading && !isMember && !joinedNow;
+
+  function handleConfirmJoin() {
+    joinMutation.mutate(eventId, {
+      onSuccess: () => {
+        setJoinedNow(true);
+        pushToast("모임에 가입되었어요");
+      },
+      onError: (error) => {
+        pushToast(error instanceof Error ? error.message : "가입에 실패했어요");
+      },
+    });
+  }
 
   function handleSubmit(answers: Array<{ fieldId: number; value: string }>) {
     mutation.mutate(
@@ -55,9 +82,38 @@ export default function Register() {
       <EventRegistrationForm
         event={event}
         submitLabel="사전 등록하기"
-        submitting={mutation.isPending}
+        submitting={mutation.isPending || needsJoinPrompt}
         onSubmit={handleSubmit}
       />
+
+      {needsJoinPrompt && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center p-5 bg-on-surface/40 backdrop-blur-[2px]">
+          <div className="bg-surface-container-lowest rounded-2xl p-6 max-w-sm w-full text-center shadow-xl border border-outline-variant">
+            <h2 className="text-xl font-bold text-on-surface mb-2">
+              모임에 등록하시겠습니까?
+            </h2>
+            <p className="text-sm text-on-surface-variant mb-6">
+              사전 등록을 진행하려면 먼저 이 모임의 멤버가 되어야 합니다.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => navigate(-1)}
+                disabled={joinMutation.isPending}
+                className="flex-1 border-2 border-outline-variant text-on-surface py-3 rounded-xl text-base font-semibold active:scale-[0.98] transition-transform disabled:opacity-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleConfirmJoin}
+                disabled={joinMutation.isPending}
+                className="flex-1 bg-gradient-to-br from-primary to-primary-container text-on-primary py-3 rounded-xl text-base font-semibold active:scale-[0.98] transition-transform disabled:opacity-50"
+              >
+                {joinMutation.isPending ? "가입 중..." : "확인"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
직전 refactor 머지 과정에서 Register 페이지가 EventRegistrationForm 컴포넌트로 분리되며 useMyClubs / useJoinClubViaEvent 연결과 가입 모달 JSX 가 함께 빠짐. 사전 등록 후에도 클럽 멤버에는 추가되지 않던 문제
원인.

useMyClubs 로 event.clubId 의 멤버 여부 확인 → 비멤버면 '모임에
등록하시겠습니까?' 모달 노출(폼 위 오버레이). 확인 시 join-via-event
호출 후 폼 활성, 취소 시 navigate(-1). 모달 떠있는 동안 폼 제출
버튼도 비활성.

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #4 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

-
-
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] 💄 Style - UI/스타일 변경
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 📸 스크린샷

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

| Before | After |
|--------|-------|
|        |       |

---

## 🧪 테스트

### 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 성공
- [ ] 로컬에서 테스트 완료
- [ ] 반응형 (모바일/데스크톱) 확인
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

1. 
2. 
3. 

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 등록 시 모임 가입 여부를 확인하고 미가입 사용자에게 가입 안내 모달 제공
  * 모달에서 가입 확인 시 자동으로 모임에 가입 후 사전 등록 진행
  * 가입 완료 후 확인 메시지 표시

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Q-Check23/FrontEnd/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->