### PR TITLE
fix: 체크인 상태 오판 및 입장 완료 후 Discord 페이지 이탈 수정

### DIFF
--- a/src/hooks/queries/useMyEventRegistration.ts
+++ b/src/hooks/queries/useMyEventRegistration.ts
@@ -7,5 +7,8 @@ export function useMyEventRegistration(eventId: number) {
     queryKey: queryKeys.events.myRegistration(eventId),
     queryFn: () => getMyEventRegistration(eventId),
     enabled: eventId > 0,
+    // 체크인 상태는 행동에 직결되는 값이라 항상 신선해야 한다.
+    // stale 캐시(REGISTERED)로 자동 체크인을 오판하지 않도록 0으로 둔다.
+    staleTime: 0,
   });
 }

--- a/src/pages/Checkin/Checkin.tsx
+++ b/src/pages/Checkin/Checkin.tsx
@@ -7,6 +7,7 @@ import {
   useSelfCheckIn,
 } from "../../hooks";
 import { useToastStore } from "../../stores/useToastStore";
+import { ApiError } from "../../api/client";
 import BackHeader from "../../components/BackHeader";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import ErrorFallback from "../../components/ErrorFallback";
@@ -19,8 +20,11 @@ export default function Checkin() {
   const eventId = Number(searchParams.get("eventId"));
 
   const { data: event, isLoading, isError, refetch } = useEventDetail(eventId);
-  const { data: myRegistration, isLoading: regLoading } =
-    useMyEventRegistration(eventId);
+  const {
+    data: myRegistration,
+    isLoading: regLoading,
+    isFetching: regFetching,
+  } = useMyEventRegistration(eventId);
   const createMutation = useCreateRegistration(eventId);
   const selfCheckInMutation = useSelfCheckIn(eventId);
 
@@ -48,6 +52,19 @@ export default function Checkin() {
           goToDetail();
         },
         onError: (error) => {
+          // 이미 체크인된 상태(409)는 사실상 성공 — 멱등 처리.
+          // stale 캐시로 REGISTERED라 판단해 self-check-in을 쐈는데
+          // 서버는 이미 CHECKED_IN인 경우, 백엔드 영문 메시지를 그대로
+          // 노출하지 않고 친화적 문구로 안내한다.
+          if (error instanceof ApiError && error.status === 409) {
+            pushToast(
+              error.message.includes("checked in")
+                ? "이미 참여 완료된 행사예요"
+                : error.message,
+            );
+            goToDetail();
+            return;
+          }
           // 등록은 유지되므로 상세 페이지에서 상태 확인/재시도 가능
           pushToast(
             error instanceof Error ? error.message : "참여 처리에 실패했어요",
@@ -60,12 +77,15 @@ export default function Checkin() {
 
   // 케이스 4: 이미 사전 등록된 사용자는 곧바로 체크인 처리 (1회만)
   useEffect(() => {
-    if (regLoading || !isRegistered || completedRef.current) return;
+    // regFetching까지 기다려 신선한 상태로만 판단한다.
+    // (staleTime=0이라 캐시가 있어도 백그라운드 재요청이 끝난 뒤 결정)
+    if (regLoading || regFetching || !isRegistered || completedRef.current)
+      return;
     completedRef.current = true;
     completeCheckIn(Boolean(isCheckedIn));
     // completeCheckIn은 의도적으로 deps에서 제외 (1회 실행 가드)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [regLoading, isRegistered, isCheckedIn]);
+  }, [regLoading, regFetching, isRegistered, isCheckedIn]);
 
   function handleSubmit(answers: Array<{ fieldId: number; value: string }>) {
     createMutation.mutate(

--- a/src/pages/EventInfo/EventInfo.tsx
+++ b/src/pages/EventInfo/EventInfo.tsx
@@ -196,7 +196,12 @@ export default function EventInfo() {
       <footer className="fixed bottom-0 left-0 w-full z-50 bg-surface/80 backdrop-blur-md p-5 shadow-[0px_-4px_20px_rgba(0,0,0,0.04)] flex gap-3">
         {isCheckedIn ? (
           <button
-            onClick={() => navigate(-1)}
+            onClick={() =>
+              navigate(
+                event ? `/group-events?clubId=${event.clubId}` : "/home",
+                { replace: true },
+              )
+            }
             className="flex-1 h-14 bg-gradient-to-br from-primary-container to-primary text-white rounded-xl text-xl font-semibold shadow-lg active:scale-95 transition-all flex items-center justify-center gap-2"
           >
             <span


### PR DESCRIPTION
- useMyEventRegistration staleTime=0: stale REGISTERED 캐시로 자동 체크인을 오판해 백엔드 영문 "Already checked in"이 노출되던 문제 해결
- Checkin: 자동 체크인 effect에 isFetching 게이트 추가(신선한 상태로만 판단), 409는 멱등 성공으로 처리해 친화적 문구로 안내
- EventInfo: 입장 완료 버튼 navigate(-1) → 모임 상세로 replace 이동. OAuth replace 체인으로 히스토리에 남던 Discord 인가 페이지 이탈 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 수정 사항

* **버그 수정**
  * 체크인 상태 확인 타이밍을 개선하여 최신 데이터 기반의 정확한 상태 판단 지원
  * 이미 체크인된 경우 사용자 친화적 메시지 표시
  * 체크인 완료 후 이벤트 목록 페이지로의 안정적인 네비게이션 처리

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Q-Check23/FrontEnd/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->