### PR TITLE
fix: 회원가입 화면 정렬 통일 및 '중복 확인' 버튼 오버플로우 해결

### DIFF
--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -141,100 +141,98 @@ export default function Login() {
         : "text-gray-500";
 
   return (
-    <div className="h-full w-full flex flex-col items-center justify-start gap-16">
-      <div className="self-start mt-10 ml-10">
+    <div className="h-full w-full overflow-y-auto px-5 py-10">
+      <header className="mb-8">
         <h1 className="text-2xl font-bold">회원가입</h1>
         <p className="mt-2 text-sm text-gray-500">
           Discord 인증 후 추가 정보를 입력해주세요.
         </p>
-      </div>
+      </header>
 
-      <div className="h-full w-full flex flex-col p-5">
-        <form onSubmit={onSubmit} className="flex flex-col gap-5">
-          {/* 이름 */}
-          <div>
+      <form onSubmit={onSubmit} className="flex flex-col gap-5">
+        {/* 이름 */}
+        <div>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="성명"
+            className="w-full h-11 rounded-xl border border-gray-200 outline-none focus:border-gray-400 px-4"
+          />
+          <p className="text-xs text-gray-500 text-left pl-3 pt-2">
+            정산시 사용되니 실명으로 입력해주세요.
+          </p>
+        </div>
+
+        {/* 아이디 */}
+        <div>
+          <div className="flex items-center gap-2">
             <input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="성명"
-              className="w-full h-11 rounded-xl border border-gray-200 outline-none focus:border-gray-400 p-5"
+              value={username}
+              onChange={(e) => resetUsernameCheck(e.target.value)}
+              placeholder="아이디"
+              className="flex-1 min-w-0 h-11 rounded-xl border border-gray-200 outline-none focus:border-gray-400 px-4"
             />
-            <p className="text-xs text-gray-500 text-left pl-3 pt-2">
-              정산시 사용되니 실명으로 입력해주세요.
-            </p>
-          </div>
-
-          {/* 아이디 */}
-          <div>
-            <div className="flex items-center gap-2">
-              <input
-                value={username}
-                onChange={(e) => resetUsernameCheck(e.target.value)}
-                placeholder="아이디"
-                className="flex-1 h-11 rounded-xl border border-gray-200 outline-none focus:border-gray-400 px-5"
-              />
-              <button
-                type="button"
-                onClick={handleUsernameCheck}
-                disabled={isCheckingUsername}
-                className="shrink-0 h-11 rounded-xl border border-gray-900 px-4 text-sm font-medium text-gray-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400"
-              >
-                {isCheckingUsername ? "확인 중" : "중복 확인"}
-              </button>
-            </div>
-            <p className={`text-xs text-left pl-3 pt-2 ${usernameMessageColor}`}>
-              {usernameMessage || "회원가입 전 아이디 중복 확인을 진행해주세요."}
-            </p>
-          </div>
-
-          {/* 이메일 */}
-          <div className="flex items-center gap-3 w-full">
-            <input
-              value={emailId}
-              onChange={(e) => setEmailId(e.target.value)}
-              placeholder="이메일 주소"
-              className="w-1/2 h-11 rounded-xl border border-gray-200 px-4 outline-none focus:border-gray-400"
-            />
-
-            <span className="shrink-0 text-gray-700 font-medium">@</span>
-
-            <select
-              value={domain}
-              onChange={(e) => setDomain(e.target.value)}
-              className="w-1/2 h-11 rounded-xl border border-gray-200 px-4 outline-none focus:border-gray-400 bg-white"
+            <button
+              type="button"
+              onClick={handleUsernameCheck}
+              disabled={isCheckingUsername}
+              className="shrink-0 h-11 rounded-xl border border-gray-900 px-3 text-sm font-medium text-gray-900 whitespace-nowrap disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400"
             >
-              {domains.map((d) => (
-                <option key={d} value={d}>
-                  {d}
-                </option>
-              ))}
-            </select>
+              {isCheckingUsername ? "확인 중" : "중복 확인"}
+            </button>
           </div>
+          <p className={`text-xs text-left pl-3 pt-2 ${usernameMessageColor}`}>
+            {usernameMessage || "회원가입 전 아이디 중복 확인을 진행해주세요."}
+          </p>
+        </div>
 
-          {/* 도메인 직접 입력인 경우 */}
-          {isCustomDomain && (
-            <input
-              value={customDomain}
-              onChange={(e) => setCustomDomain(e.target.value)}
-              placeholder="도메인 직접 입력"
-              className="w-full h-11 rounded-xl border border-gray-200 outline-none focus:border-gray-400 p-5"
-            />
-          )}
-          {/* 가입 버튼 */}
-          <button
-            type="submit"
-            disabled={!isFormValid || !isUsernameAvailable || isSubmitting}
-            className={[
-              "w-full h-11 rounded-xl border outline-none",
-              isFormValid && isUsernameAvailable && !isSubmitting
-                ? "bg-gray-900 text-white cursor-pointer"
-                : "bg-gray-200 text-gray-400 cursor-not-allowed",
-            ].join(" ")}
+        {/* 이메일 */}
+        <div className="flex items-center gap-2 w-full">
+          <input
+            value={emailId}
+            onChange={(e) => setEmailId(e.target.value)}
+            placeholder="이메일 주소"
+            className="flex-1 min-w-0 h-11 rounded-xl border border-gray-200 px-4 outline-none focus:border-gray-400"
+          />
+
+          <span className="shrink-0 text-gray-700 font-medium">@</span>
+
+          <select
+            value={domain}
+            onChange={(e) => setDomain(e.target.value)}
+            className="flex-1 min-w-0 h-11 rounded-xl border border-gray-200 px-3 outline-none focus:border-gray-400 bg-white"
           >
-            {isSubmitting ? "가입 중..." : "회원가입 완료"}
-          </button>
-        </form>
-      </div>
+            {domains.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* 도메인 직접 입력인 경우 */}
+        {isCustomDomain && (
+          <input
+            value={customDomain}
+            onChange={(e) => setCustomDomain(e.target.value)}
+            placeholder="도메인 직접 입력"
+            className="w-full h-11 rounded-xl border border-gray-200 outline-none focus:border-gray-400 px-4"
+          />
+        )}
+        {/* 가입 버튼 */}
+        <button
+          type="submit"
+          disabled={!isFormValid || !isUsernameAvailable || isSubmitting}
+          className={[
+            "w-full h-11 rounded-xl border outline-none mt-2",
+            isFormValid && isUsernameAvailable && !isSubmitting
+              ? "bg-gray-900 text-white cursor-pointer"
+              : "bg-gray-200 text-gray-400 cursor-not-allowed",
+          ].join(" ")}
+        >
+          {isSubmitting ? "가입 중..." : "회원가입 완료"}
+        </button>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
- 헤더(self-start ml-10) 와 폼(p-5) 가 서로 다른 들여쓰기를 써서 화면이 비대칭으로 보이던 문제 → 바깥 컨테이너에 px-5 py-10 으로 좌우 패딩 통일, 불필요한 gap-16 제거
- 아이디 행의 input 에 min-w-0 추가 → flex 항목 기본 min-width:auto 때문에 input 이 placeholder 폭 이하로 줄지 않아 '중복 확인' 버튼이 화면 밖으로 밀려나가던 문제 해결. 이메일 행도 동일 패턴 적용
- 이름 input 의 p-5 가 h-11 와 충돌해 컨텐츠가 거의 안 보이던 부분을 px-4 로 정리
- 중복확인 버튼에 whitespace-nowrap 으로 줄바꿈 방지

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #4 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

-
-
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] 💄 Style - UI/스타일 변경
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 📸 스크린샷

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

| Before | After |
|--------|-------|
|        |       |

---

## 🧪 테스트

### 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 성공
- [ ] 로컬에서 테스트 완료
- [ ] 반응형 (모바일/데스크톱) 확인
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

1. 
2. 
3. 

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->
