### PR TITLE
fix: 이미 체크인된 행사 재진입 시 중복 토스트 제거

### DIFF
--- a/src/hooks/mutations/useSelfCheckIn.ts
+++ b/src/hooks/mutations/useSelfCheckIn.ts
@@ -10,6 +10,9 @@ export function useSelfCheckIn(eventId?: number) {
 
   return useMutation({
     mutationFn: (body: SelfCheckInRequest) => selfCheckInAttendance(body),
+    // 전역 onError(백엔드 영문 메시지 토스트)를 끄고, 에러 노출은
+    // 화면(Checkin)의 mutate 콜백에서 한글 문구로 직접 처리한다.
+    onError: () => {},
     onSuccess: () => {
       if (eventId) {
         queryClient.invalidateQueries({

--- a/src/pages/Checkin/Checkin.tsx
+++ b/src/pages/Checkin/Checkin.tsx
@@ -39,7 +39,7 @@ export default function Checkin() {
       navigate(`/event-info?eventId=${eventId}`, { replace: true });
 
     if (alreadyCheckedIn) {
-      pushToast("이미 참여 완료된 행사예요");
+      // 이미 참여 완료된 상태는 정상이므로 토스트 없이 상세로 이동
       goToDetail();
       return;
     }
@@ -54,14 +54,12 @@ export default function Checkin() {
         onError: (error) => {
           // 이미 체크인된 상태(409)는 사실상 성공 — 멱등 처리.
           // stale 캐시로 REGISTERED라 판단해 self-check-in을 쐈는데
-          // 서버는 이미 CHECKED_IN인 경우, 백엔드 영문 메시지를 그대로
-          // 노출하지 않고 친화적 문구로 안내한다.
+          // 서버는 이미 CHECKED_IN인 경우다. 정상 상태이므로 토스트 없이
+          // 조용히 상세로 이동한다. (단, 체크인 외 다른 409는 안내한다)
           if (error instanceof ApiError && error.status === 409) {
-            pushToast(
-              error.message.includes("checked in")
-                ? "이미 참여 완료된 행사예요"
-                : error.message,
-            );
+            if (!error.message.includes("checked in")) {
+              pushToast(error.message);
+            }
             goToDetail();
             return;
           }


### PR DESCRIPTION
이미 참여 완료된 행사를 다시 체크인할 때 전역 onError의 백엔드 영문
메시지("Already checked in")와 화면 한글 토스트가 함께 떠 중복으로
노출되던 문제 수정.

- useSelfCheckIn: 전역 영문 에러 토스트를 끄고 화면이 직접 처리
- Checkin: 이미 체크인된 상태는 정상이므로 토스트 없이 상세로 이동