### PR TITLE
fix: 행사 상세에서 동작하지 않는 '지도 보기' 텍스트 제거

### DIFF
--- a/src/pages/EventInfo/EventInfo.tsx
+++ b/src/pages/EventInfo/EventInfo.tsx
@@ -172,9 +172,6 @@ export default function EventInfo() {
               <p className="text-base font-bold">
                 {event?.location || "-"}
               </p>
-              <p className="text-xs font-semibold text-on-surface-variant underline cursor-pointer">
-                지도 보기
-              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
EventInfo 의 장소 아래 '지도 보기' 가 underline·cursor-pointer 만 달려있고 실제 onClick 이 없는 비활성 UI 라 사용자에게 깨진 인상.
지도 연동 자체가 없는 상태이므로 단순 제거.

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #4 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

-
-
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] 💄 Style - UI/스타일 변경
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 📸 스크린샷

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

| Before | After |
|--------|-------|
|        |       |

---

## 🧪 테스트

### 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 성공
- [ ] 로컬에서 테스트 완료
- [ ] 반응형 (모바일/데스크톱) 확인
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

1. 
2. 
3. 

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->
