### PR TITLE
fix: 서버 시각 표시에 KST(+9h) 보정 적용

### DIFF
--- a/src/lib/datetime.NOTES.md
+++ b/src/lib/datetime.NOTES.md
@@ -1,0 +1,38 @@
+# 시각 표시 KST(+9h) 보정 — 적용 범위 메모
+
+서버가 타임존 없는 UTC `LocalDateTime` 을 내려주기 때문에, 프론트에서 서버 시각
+문자열을 파싱할 때 `parseKST()` (`src/lib/datetime.ts`) 로 9시간을 더해 한국 시간으로
+표시한다.
+
+> ⚠️ 임시 보정이다. 근본 원인은 서버 JVM 이 UTC 라는 점이며, 백엔드 타임존을
+> 정리하면 여기 `parseKST` 호출들을 같이 걷어내야 한다. 그렇지 않으면 이중 보정된다.
+
+## 적용한 곳 (서버 시각 문자열 → `parseKST`)
+
+- `pages/EventParticipants/EventParticipants.tsx` — QR/수동 체크인 시각
+- `pages/DashBoard/DashBoard.tsx` — 행사 일시
+- `pages/EventInfo/EventInfo.tsx` — 행사 날짜·시간 + 등록 마감 30분 컷오프 계산
+- `pages/GroupEvents/components/EventCard.tsx` — 행사 목록 날짜·시간
+- `pages/Home/components/EventSearchCard.tsx` — 검색 결과 날짜
+- `pages/Home/components/ScheduleList.tsx` — 일정 목록 시간 (`formatTime` 만)
+- `pages/Home/Home.tsx` — 캘린더 day 버킷팅 (표시 시간과 같은 날짜에 묶이도록)
+- `pages/GroupNotice/GroupNotice.tsx` — 공지 "N분 전"
+- `pages/NoticeDetail/NoticeDetail.tsx` — 공지 작성 날짜·시간
+
+## 일부러 건드리지 않은 곳
+
+### 서버 시각이 아닌 Date 생성 — 보정하면 오히려 깨짐
+- `pages/Home/components/Calendar.tsx` (line 16, 30, 31, 32)
+  — `new Date(year, month-1, …)` 숫자 기반 달력 격자 계산. 시각 표시가 아니다.
+- `pages/Home/components/ScheduleList.tsx` (line 13 `formatDateHeading`)
+  — `new Date(year, month-1, day)` 숫자 기반 날짜 헤딩.
+- `pages/Home/Home.tsx` (line 14)
+  — `new Date()` 오늘 날짜(로컬 현재 시각). 서버 값 아님.
+
+### 양방향 read/write 경로 — 별도 처리 필요
+- `pages/EditEvent/EditEvent.tsx`
+  - `splitDateTime` (line 11): 서버 `startTime` 을 수정 폼 입력칸으로 분해
+  - `handleSubmit` (line 85): 입력값을 `new Date(\`${date}T${time}\`).toISOString()` 로
+    다시 UTC(Z 접미사) 변환해 전송
+  - 읽기에만 +9h 를 넣으면 저장 경로의 `.toISOString()` 변환과 어긋나 데이터가
+    틀어진다. 표시 버그와 성격이 다른 read/write 정합성 문제라 분리해서 다뤄야 한다.

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,0 +1,12 @@
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * 백엔드가 타임존 없는 UTC 시각(LocalDateTime)을 내려주므로,
+ * 화면 표시 전에 9시간(KST)을 더해 한국 시간으로 보정한다.
+ *
+ * 숫자 인자로 Date 를 만드는 곳(달력 격자 등)에는 쓰지 말 것 — 서버에서 받은
+ * 시각 문자열에만 적용한다.
+ */
+export function parseKST(value: string): Date {
+  return new Date(new Date(value).getTime() + KST_OFFSET_MS);
+}

--- a/src/pages/DashBoard/DashBoard.tsx
+++ b/src/pages/DashBoard/DashBoard.tsx
@@ -4,6 +4,7 @@ import { useToastStore } from "../../stores/useToastStore";
 import EventManageHeader from "../../components/EventManageHeader";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import ErrorFallback from "../../components/ErrorFallback";
+import { parseKST } from "../../lib/datetime";
 
 export default function DashBoard() {
   const [searchParams] = useSearchParams();
@@ -194,7 +195,7 @@ function InfoRow({
 
 function formatDateTime(startTime: string) {
   try {
-    const d = new Date(startTime);
+    const d = parseKST(startTime);
     if (!isNaN(d.getTime())) {
       return d.toLocaleString("ko-KR", {
         year: "numeric",

--- a/src/pages/EventInfo/EventInfo.tsx
+++ b/src/pages/EventInfo/EventInfo.tsx
@@ -4,10 +4,11 @@ import { useToastStore } from "../../stores/useToastStore";
 import BackHeader from "../../components/BackHeader";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import ErrorFallback from "../../components/ErrorFallback";
+import { parseKST } from "../../lib/datetime";
 
 function isBeforeRegistrationCutoff(startTime?: string): boolean {
   if (!startTime) return false;
-  const start = new Date(startTime).getTime();
+  const start = parseKST(startTime).getTime();
   if (isNaN(start)) return false;
   return Date.now() < start - 30 * 60 * 1000;
 }
@@ -247,7 +248,7 @@ export default function EventInfo() {
 function formatDate(startTime?: string) {
   if (!startTime) return "-";
   try {
-    const d = new Date(startTime);
+    const d = parseKST(startTime);
     if (!isNaN(d.getTime())) {
       const mm = String(d.getMonth() + 1).padStart(2, "0");
       const dd = String(d.getDate()).padStart(2, "0");
@@ -263,7 +264,7 @@ function formatDate(startTime?: string) {
 function formatTime(startTime?: string) {
   if (!startTime) return "-";
   try {
-    const d = new Date(startTime);
+    const d = parseKST(startTime);
     if (!isNaN(d.getTime())) {
       return d.toLocaleTimeString("ko-KR", {
         hour: "2-digit",

--- a/src/pages/EventParticipants/EventParticipants.tsx
+++ b/src/pages/EventParticipants/EventParticipants.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { type EventRegistration } from "../../api/events";
 import { useEventRegistrations } from "../../hooks";
+import { parseKST } from "../../lib/datetime";
 import { useToastStore } from "../../stores/useToastStore";
 import EventManageHeader from "../../components/EventManageHeader";
 import LoadingSpinner from "../../components/LoadingSpinner";
@@ -183,7 +184,7 @@ function ParticipantCard({
 }
 
 function formatCheckInTime(value: string) {
-  const d = new Date(value);
+  const d = parseKST(value);
   if (isNaN(d.getTime())) return value;
   return d.toLocaleString("ko-KR", {
     month: "long",

--- a/src/pages/GroupEvents/components/EventCard.tsx
+++ b/src/pages/GroupEvents/components/EventCard.tsx
@@ -1,4 +1,5 @@
 import type { EventSummary } from "../../../api/events";
+import { parseKST } from "../../../lib/datetime";
 
 interface EventCardProps {
   event: EventSummary;
@@ -9,7 +10,7 @@ interface EventCardProps {
 function formatEventDate(startTime: string) {
   if (!startTime) return "";
   try {
-    const d = new Date(startTime);
+    const d = parseKST(startTime);
     if (!isNaN(d.getTime())) {
       const mm = String(d.getMonth() + 1).padStart(2, "0");
       const dd = String(d.getDate()).padStart(2, "0");
@@ -26,7 +27,7 @@ function formatEventDate(startTime: string) {
 function formatEventTime(startTime: string) {
   if (!startTime) return "";
   try {
-    const d = new Date(startTime);
+    const d = parseKST(startTime);
     if (!isNaN(d.getTime())) {
       return d.toLocaleTimeString("ko-KR", {
         hour: "2-digit",

--- a/src/pages/GroupNotice/GroupNotice.tsx
+++ b/src/pages/GroupNotice/GroupNotice.tsx
@@ -10,9 +10,10 @@ import {
   useNotices,
   useCreateNotice,
 } from "../../hooks";
+import { parseKST } from "../../lib/datetime";
 
 function formatTimeAgo(dateString: string) {
-  const diff = Date.now() - new Date(dateString).getTime();
+  const diff = Date.now() - parseKST(dateString).getTime();
   const minutes = Math.floor(diff / 60_000);
   if (minutes < 1) return "방금 전";
   if (minutes < 60) return `${minutes}분 전`;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -8,6 +8,7 @@ import ScheduleList from "./components/ScheduleList";
 import BottomSheet from "./components/BottomSheet";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import ErrorFallback from "../../components/ErrorFallback";
+import { parseKST } from "../../lib/datetime";
 
 export default function Home() {
   const navigate = useNavigate();
@@ -28,7 +29,7 @@ export default function Home() {
     const dates = new Set<number>();
     for (const event of allEvents) {
       if (event.startTime) {
-        const d = new Date(event.startTime);
+        const d = parseKST(event.startTime);
         if (
           d.getFullYear() === year &&
           d.getMonth() + 1 === month
@@ -44,7 +45,7 @@ export default function Home() {
     if (selectedDate === null) return [];
     return allEvents.filter((event) => {
       if (!event.startTime) return false;
-      const d = new Date(event.startTime);
+      const d = parseKST(event.startTime);
       return (
         d.getFullYear() === year &&
         d.getMonth() + 1 === month &&

--- a/src/pages/Home/components/EventSearchCard.tsx
+++ b/src/pages/Home/components/EventSearchCard.tsx
@@ -1,4 +1,5 @@
 import type { CalendarEvent } from "../../../api/calendar";
+import { parseKST } from "../../../lib/datetime";
 
 interface EventSearchCardProps {
   event: CalendarEvent;
@@ -8,7 +9,7 @@ interface EventSearchCardProps {
 function formatDate(startTime: string) {
   if (!startTime) return "";
   try {
-    const d = new Date(startTime);
+    const d = parseKST(startTime);
     if (!isNaN(d.getTime())) {
       const y = d.getFullYear();
       const m = String(d.getMonth() + 1).padStart(2, "0");

--- a/src/pages/Home/components/ScheduleList.tsx
+++ b/src/pages/Home/components/ScheduleList.tsx
@@ -1,5 +1,6 @@
 import type { CalendarEvent } from "../../../api/calendar";
 import ScheduleCard from "./ScheduleCard";
+import { parseKST } from "../../../lib/datetime";
 
 interface ScheduleListProps {
   year: number;
@@ -21,7 +22,7 @@ function formatTime(startTime: string) {
   if (!startTime) return "";
   // startTime comes as ISO or "HH:mm" format
   try {
-    const date = new Date(startTime);
+    const date = parseKST(startTime);
     if (!isNaN(date.getTime())) {
       return date.toLocaleTimeString("ko-KR", {
         hour: "2-digit",

--- a/src/pages/NoticeDetail/NoticeDetail.tsx
+++ b/src/pages/NoticeDetail/NoticeDetail.tsx
@@ -3,10 +3,11 @@ import { useNotices } from "../../hooks";
 import BackHeader from "../../components/BackHeader";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import ErrorFallback from "../../components/ErrorFallback";
+import { parseKST } from "../../lib/datetime";
 
 function formatDate(dateString: string) {
   try {
-    const d = new Date(dateString);
+    const d = parseKST(dateString);
     if (isNaN(d.getTime())) return dateString;
     const mm = String(d.getMonth() + 1).padStart(2, "0");
     const dd = String(d.getDate()).padStart(2, "0");
@@ -19,7 +20,7 @@ function formatDate(dateString: string) {
 
 function formatTime(dateString: string) {
   try {
-    const d = new Date(dateString);
+    const d = parseKST(dateString);
     if (isNaN(d.getTime())) return "";
     return d.toLocaleTimeString("ko-KR", {
       hour: "2-digit",


### PR DESCRIPTION
서버가 타임존 없는 UTC LocalDateTime을 내려줘 체크인·행사·공지 시각이
9시간 빠르게 표시되던 문제 수정. parseKST 헬퍼(src/lib/datetime.ts)로 서버 시각 문자열 파싱을 일괄 보정.

- 체크인 시각, 행사 일시, 공지 작성 시각, 캘린더 day 버킷팅에 적용
- 적용 범위/제외 항목은 src/lib/datetime.NOTES.md 에 정리
- 숫자 기반 Date 생성(캘린더 격자)과 EditEvent 양방향 폼은 의도적으로 제외
