### PR TITLE
fix: 토스트 가시화 개선 — 위치/스타일/지속시간/애니메이션

### DIFF
--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,4 +1,22 @@
-import { useToastStore } from "../stores/useToastStore";
+import { useToastStore, type ToastVariant } from "../stores/useToastStore";
+
+const VARIANT_STYLES: Record<
+  ToastVariant,
+  { container: string; icon: string }
+> = {
+  success: {
+    container: "bg-emerald-600 text-white",
+    icon: "check_circle",
+  },
+  error: {
+    container: "bg-red-600 text-white",
+    icon: "error",
+  },
+  info: {
+    container: "bg-on-surface/90 text-surface",
+    icon: "info",
+  },
+};
 
 export default function ToastContainer() {
   const toasts = useToastStore((s) => s.toasts);
@@ -6,15 +24,22 @@ export default function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed left-4 bottom-4 z-[100] flex flex-col gap-2">
-      {toasts.map((t) => (
-        <div
-          key={t.id}
-          className="px-4 py-3 rounded-xl bg-on-surface/80 text-surface text-sm shadow-lg animate-[fadeIn_0.2s_ease-out]"
-        >
-          {t.message}
-        </div>
-      ))}
+    <div className="fixed left-1/2 bottom-24 z-[100] flex flex-col gap-2 -translate-x-1/2 items-center pointer-events-none w-[calc(100%-2rem)] max-w-sm">
+      {toasts.map((t) => {
+        const style = VARIANT_STYLES[t.variant];
+        return (
+          <div
+            key={t.id}
+            className={`flex items-center gap-2 px-4 py-3 rounded-xl text-sm font-medium shadow-xl pointer-events-auto whitespace-pre-line text-center ${style.container}`}
+            style={{ animation: "toastFadeIn 0.22s ease-out" }}
+          >
+            <span className="material-symbols-outlined text-[20px] shrink-0">
+              {style.icon}
+            </span>
+            <span className="flex-1">{t.message}</span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -85,6 +85,17 @@ button, input {
   color: #000;
 }
 
+@keyframes toastFadeIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 12px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
 @layer utilities {
   .t-placeholder {
     @apply placeholder:font-sans placeholder:text-ui14 placeholder:font-ui500 placeholder:text-ui-grayC0;

--- a/src/pages/Checkin/Checkin.tsx
+++ b/src/pages/Checkin/Checkin.tsx
@@ -49,7 +49,7 @@ export default function Checkin() {
       { eventId },
       {
         onSuccess: () => {
-          pushToast("참여가 완료되었어요");
+          pushToast("참여가 완료되었어요", "success");
           goToDetail();
         },
         onError: (error) => {

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -46,7 +46,7 @@ export default function Register() {
       { answers },
       {
         onSuccess: () => {
-          pushToast("사전 등록이 완료되었어요");
+          pushToast("사전 등록이 완료되었어요", "success");
           navigate(`/event-info?eventId=${eventId}`);
         },
         onError: (error) => {

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -1,22 +1,27 @@
 import { create } from "zustand";
 
+export type ToastVariant = "info" | "success" | "error";
+
 interface Toast {
   id: number;
   message: string;
+  variant: ToastVariant;
 }
 
 interface ToastState {
   toasts: Toast[];
-  push: (message: string) => void;
+  push: (message: string, variant?: ToastVariant) => void;
 }
+
+const TOAST_DURATION_MS = 3500;
 
 export const useToastStore = create<ToastState>((set) => ({
   toasts: [],
-  push: (message) => {
-    const id = Date.now();
-    set((state) => ({ toasts: [...state.toasts, { id, message }] }));
+  push: (message, variant = "info") => {
+    const id = Date.now() + Math.floor(Math.random() * 1000);
+    set((state) => ({ toasts: [...state.toasts, { id, message, variant }] }));
     setTimeout(() => {
       set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
-    }, 2500);
+    }, TOAST_DURATION_MS);
   },
 }));


### PR DESCRIPTION
## Summary
- 사전등록/체크인 완료 토스트가 안 보이던 문제 수정
- 토스트 위치를 하단 중앙으로 이동, 성공/에러 variant 추가, 등장 애니메이션 정의, 지속시간 연장

## 원인
1. **위치 충돌**: [ToastContainer.tsx:9](https://github.com/Q-Check23/FrontEnd/blob/fix/toast-visibility/src/components/ToastContainer.tsx) 가 \`fixed left-4 bottom-4\` 인데, 사전등록/체크인 완료 후 이동하는 EventInfo 페이지가 \`fixed bottom-0 w-full z-50\` 의 두꺼운 footer 를 가지고 있어 시각적으로 묻혔음
2. **애니메이션 미정의**: \`animate-[fadeIn_0.2s_ease-out]\` 가 적용돼 있지만 \`fadeIn\` 키프레임 자체가 어디에도 정의 안 됨 → 등장 효과 없음
3. **짧은 지속시간**: 2500ms 자동 dismiss + 즉시 navigate 조합으로 페이지 전환 직후 사용자 시선이 새 페이지의 큰 버튼/콘텐츠로 옮겨가서 작은 코너 토스트를 인지 못 함

## 변경 내용
- **ToastContainer.tsx**: 위치 \`left-1/2 bottom-24 -translate-x-1/2\` (하단 중앙, footer 위쪽). 아이콘 + 강조 컬러로 success(에메랄드)/error(레드)/info(다크) variant 분리
- **useToastStore.ts**: \`push(message, variant?)\` 시그니처. 기본 \`info\` 라 기존 호출부 영향 없음. 지속시간 2500ms → 3500ms
- **index.css**: \`@keyframes toastFadeIn\` 정의 (slide-up + opacity)
- **Register.tsx / Checkin.tsx**: 사전등록 완료, 체크인 완료 토스트에만 \`"success"\` variant 명시. 그 외 50+ 호출부는 기본 info 로 그대로 동작

## Test plan
- [ ] /home 에서 사전등록 링크 진입 → 등록 완료 → 하단 중앙 에메랄드 토스트 \"사전 등록이 완료되었어요\" 가 명확히 보이는지 확인
- [ ] 체크인 셀프 흐름에서 \"참여가 완료되었어요\" 토스트 확인
- [ ] iPhone Safari / Android Chrome 양쪽 모바일 환경
- [ ] 다른 페이지(GroupMembers, DashBoard 등)의 기본 info 토스트도 새 위치/스타일로 정상 표시되는지 회귀 확인