### PR TITLE
feat: 회원가입 폼에 휴대폰 번호 입력 필드 추가

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -13,6 +13,7 @@ export interface SignupRequest {
   name: string;
   username: string;
   email: string;
+  phone: string;
 }
 
 export interface AuthTokenResponse {

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -11,6 +11,7 @@ export default function Login() {
   const [signupToken, setSignupToken] = useState("");
   const [name, setName] = useState("");
   const [username, setUsername] = useState("");
+  const [phone, setPhone] = useState("");
   const [emailId, setEmailId] = useState("");
   const [domain, setDomain] = useState("gmail.com");
   const [isCheckingUsername, setIsCheckingUsername] = useState(false);
@@ -41,6 +42,7 @@ export default function Login() {
   const isFormValid =
     name.trim().length > 0 &&
     username.trim().length > 0 &&
+    phone.trim().length > 0 &&
     emailId.trim().length > 0 &&
     (isCustomDomain ? customDomain.trim().length > 0 : true);
 
@@ -116,6 +118,7 @@ export default function Login() {
           name: name.trim(),
           username: username.trim(),
           email: finalEmail,
+          phone: phone.trim(),
         },
         signupToken,
       );
@@ -183,6 +186,21 @@ export default function Login() {
           </div>
           <p className={`text-xs text-left pl-3 pt-2 ${usernameMessageColor}`}>
             {usernameMessage || "회원가입 전 아이디 중복 확인을 진행해주세요."}
+          </p>
+        </div>
+
+        {/* 휴대폰 번호 */}
+        <div>
+          <input
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="휴대폰 번호 (예: 010-1234-5678)"
+            inputMode="tel"
+            autoComplete="tel"
+            className="w-full h-11 rounded-xl border border-gray-200 outline-none focus:border-gray-400 px-4"
+          />
+          <p className="text-xs text-gray-500 text-left pl-3 pt-2">
+            행사 사전등록 시 자동으로 채워집니다.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- 회원가입 시 휴대폰 번호 입력 필드 추가
- 사전등록/체크인 폼의 \"연락처 (전화번호)\" 필드 자동채움이 동작하도록 \`User.phone\` 을 가입 시점에 받음
- 백엔드 [BackEnd#40](https://github.com/Q-Check23/BackEnd/pull/40) 와 짝

## 변경 내용
- \`src/api/auth.ts\`: \`SignupRequest\` 에 \`phone: string\` 필드 추가
- \`src/pages/Login/Login.jsx\`:
  - \`phone\` state 추가
  - 아이디와 이메일 사이에 휴대폰 입력 input (\`inputMode=\"tel\"\`, \`autoComplete=\"tel\"\`)
  - \`isFormValid\` 검증에 phone 포함
  - signup API 호출 payload 에 \`phone: phone.trim()\` 포함

## 자동채움 흐름 (이미 구현돼 있음)
[EventRegistrationForm.tsx:21-30](https://github.com/Q-Check23/FrontEnd/blob/main/src/components/EventRegistrationForm.tsx#L21) 의 \`guessProfileValue\` 가 \`/전화|연락처|휴대폰|핸드폰|phone|mobile/i\` 정규식 매칭으로 \`profile.phone\` 을 채워줌. 가입 시 phone 만 들어가면 그 다음 사전등록부터 곧바로 자동 채움 동작.

## 배포 순서
**백엔드 PR #40 먼저 머지·배포** → 이 PR 머지. 반대 순서면 프론트가 보낸 phone 을 백엔드가 무시한 채 가입이 진행돼 자동채움이 안 됨.

## Test plan
- [ ] 백엔드 #40 배포 후 새 계정 가입 → 사전등록 페이지 진입 → \"연락처 (전화번호)\" 필드가 가입 시 입력한 번호로 자동 채워지는지 확인
- [ ] 빈 phone 으로 가입 시도 시 \"회원가입 완료\" 버튼이 비활성화돼 있는지 확인