### PR TITLE
feat: 사전등록 정보 수집 토글 UI

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -55,6 +55,7 @@ export interface CreateEventRequest {
   location?: string;
   createDiscordChannel?: boolean;
   discordChannelId?: string;
+  collectRegistrationInfo: boolean;
   formFields: CreateEventFormField[];
 }
 
@@ -83,6 +84,7 @@ interface EventDetailResponse {
   location: string | null;
   discordChannelId: string | null;
   isActive: boolean | null;
+  collectRegistrationInfo: boolean | null;
   formFields: EventFormFieldResponse[] | null;
 }
 
@@ -95,6 +97,7 @@ export interface EventDetail {
   location: string;
   discordChannelId: string;
   isActive: boolean;
+  collectRegistrationInfo: boolean;
   formFields: Array<{
     id: number;
     type: EventFormFieldType;
@@ -197,6 +200,8 @@ function mapEventDetail(response: EventDetailResponse): EventDetail {
     location: normalizeText(response.location),
     discordChannelId: normalizeText(response.discordChannelId),
     isActive: Boolean(response.isActive),
+    // 백엔드가 null/undefined 를 내려보내는 (구버전) 경우는 기본 ON 으로 해석 — 명시적 false 일 때만 폼 스킵
+    collectRegistrationInfo: response.collectRegistrationInfo !== false,
     formFields: (response.formFields ?? []).map((field) => ({
       id: field.id,
       type: field.type === "SELECT" ? "SELECT" : "TEXT",

--- a/src/pages/Checkin/Checkin.tsx
+++ b/src/pages/Checkin/Checkin.tsx
@@ -135,12 +135,47 @@ export default function Checkin() {
   return (
     <div className="bg-surface h-full overflow-y-auto pb-32">
       <BackHeader title="행사 참여" subtitle={event.title} />
-      <EventRegistrationForm
-        event={event}
-        submitLabel="참여하기"
-        submitting={createMutation.isPending || selfCheckInMutation.isPending}
-        onSubmit={handleSubmit}
-      />
+      {event.collectRegistrationInfo ? (
+        <EventRegistrationForm
+          event={event}
+          submitLabel="참여하기"
+          submitting={createMutation.isPending || selfCheckInMutation.isPending}
+          onSubmit={handleSubmit}
+        />
+      ) : (
+        <>
+          <main className="px-5 py-6 space-y-6">
+            <section className="space-y-3">
+              <div className="flex items-center gap-2">
+                <span className="material-symbols-outlined text-primary text-[20px]">
+                  event_note
+                </span>
+                <h2 className="text-xl font-semibold">행사 정보</h2>
+              </div>
+              <div className="bg-surface-container-lowest p-4 rounded-xl shadow-sm space-y-1">
+                <p className="text-base font-bold">{event.title}</p>
+                <p className="text-sm text-on-surface-variant">
+                  {event.location || "장소 미정"}
+                </p>
+              </div>
+            </section>
+            <p className="text-sm text-on-surface-variant text-center pt-2">
+              별도 입력 없이 한 번의 클릭으로 참여가 완료됩니다.
+            </p>
+          </main>
+          <div className="fixed bottom-0 left-0 w-full p-5 bg-surface/70 backdrop-blur-xl z-50">
+            <button
+              onClick={() => handleSubmit([])}
+              disabled={createMutation.isPending || selfCheckInMutation.isPending}
+              className="w-full bg-gradient-to-br from-primary to-primary-container text-on-primary py-4 rounded-xl text-xl font-semibold shadow-lg active:scale-[0.98] transition-transform disabled:opacity-50"
+            >
+              {createMutation.isPending || selfCheckInMutation.isPending
+                ? "처리 중..."
+                : "참여하기"}
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/CreateEvent/CreateEvent.tsx
+++ b/src/pages/CreateEvent/CreateEvent.tsx
@@ -21,6 +21,7 @@ export default function CreateEvent() {
   const [createDiscordChannel, setCreateDiscordChannel] = useState(false);
   const [channelOption, setChannelOption] = useState<"new" | "existing">("new");
   const [discordChannelId, setDiscordChannelId] = useState("");
+  const [collectRegistrationInfo, setCollectRegistrationInfo] = useState(true);
   const [fields, setFields] = useState<FormField[]>([
     { label: "참가자 실명", required: true },
     { label: "연락처 (전화번호)", required: true },
@@ -67,14 +68,18 @@ export default function CreateEvent() {
         ...(createDiscordChannel && channelOption === "existing" && discordChannelId.trim()
           ? { discordChannelId: discordChannelId.trim() }
           : {}),
-        formFields: fields
-          .filter((f) => f.label.trim())
-          .map((f) => ({
-            type: "TEXT" as const,
-            label: f.label.trim(),
-            required: f.required,
-            options: [],
-          })),
+        collectRegistrationInfo,
+        // 토글 OFF 면 입력했던 필드들은 서버로 보내지 않음 — 백엔드도 무시하지만 의도 명확화
+        formFields: collectRegistrationInfo
+          ? fields
+              .filter((f) => f.label.trim())
+              .map((f) => ({
+                type: "TEXT" as const,
+                label: f.label.trim(),
+                required: f.required,
+                options: [],
+              }))
+          : [],
       },
       {
         onSuccess: () => navigate(-1),
@@ -257,6 +262,34 @@ export default function CreateEvent() {
         {/* 참가자 정보 수집 */}
         <section className="space-y-3">
           <SectionHeader icon="assignment_ind" title="참가자 정보 수집" />
+          <div className="bg-surface-container-lowest p-4 rounded-xl shadow-sm">
+            <label className="flex items-center justify-between cursor-pointer">
+              <div className="flex-1 pr-3">
+                <span className="text-sm font-medium text-on-surface block">
+                  참가자에게 정보를 받기
+                </span>
+                <p className="text-xs text-on-surface-variant mt-1">
+                  OFF 면 멤버는 폼 없이 “참여하기” 버튼 한 번으로 등록합니다. 생성 후엔 변경할 수 없어요.
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={collectRegistrationInfo}
+                onClick={() => setCollectRegistrationInfo((v) => !v)}
+                className={`relative w-11 h-6 rounded-full transition-colors shrink-0 ${
+                  collectRegistrationInfo ? "bg-primary" : "bg-outline-variant"
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 left-0.5 w-5 h-5 bg-surface rounded-full shadow transition-transform ${
+                    collectRegistrationInfo ? "translate-x-5" : ""
+                  }`}
+                />
+              </button>
+            </label>
+          </div>
+          {collectRegistrationInfo && (
           <div className="space-y-3">
             {fields.map((field, i) => (
               <div
@@ -323,6 +356,7 @@ export default function CreateEvent() {
               <span className="text-base font-medium">질문 추가하기</span>
             </button>
           </div>
+          )}
         </section>
       </main>
 

--- a/src/pages/EditEvent/EditEvent.tsx
+++ b/src/pages/EditEvent/EditEvent.tsx
@@ -179,6 +179,38 @@ export default function EditEvent() {
           </div>
         </section>
 
+        {/* 사전등록 정보 수집 — 생성 시 결정된 값. 표시만 하고 변경 불가 */}
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary text-[20px]">
+              assignment_ind
+            </span>
+            참가자 정보 수집
+          </h2>
+          <div className="bg-surface-container-lowest p-4 rounded-xl shadow-sm flex items-center justify-between opacity-70">
+            <div className="flex-1 pr-4">
+              <p className="text-base font-medium text-on-surface">
+                {event.collectRegistrationInfo ? "정보 수집 ON" : "정보 수집 OFF"}
+              </p>
+              <p className="text-xs text-on-surface-variant mt-1">
+                행사 생성 시에만 설정 가능합니다.
+              </p>
+            </div>
+            <div
+              className={`relative w-11 h-6 rounded-full shrink-0 ${
+                event.collectRegistrationInfo ? "bg-primary" : "bg-outline-variant"
+              }`}
+              aria-disabled
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 w-5 h-5 bg-surface rounded-full shadow ${
+                  event.collectRegistrationInfo ? "translate-x-5" : ""
+                }`}
+              />
+            </div>
+          </div>
+        </section>
+
         <section className="space-y-3">
           <h2 className="text-xl font-semibold flex items-center gap-2">
             <span className="material-symbols-outlined text-primary text-[20px]">

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -79,12 +79,50 @@ export default function Register() {
   return (
     <div className="bg-surface h-full overflow-y-auto pb-32">
       <BackHeader title="사전 등록" subtitle={event.title} />
-      <EventRegistrationForm
-        event={event}
-        submitLabel="사전 등록하기"
-        submitting={mutation.isPending || needsJoinPrompt}
-        onSubmit={handleSubmit}
-      />
+      {event.collectRegistrationInfo ? (
+        <EventRegistrationForm
+          event={event}
+          submitLabel="사전 등록하기"
+          submitting={mutation.isPending || needsJoinPrompt}
+          onSubmit={handleSubmit}
+        />
+      ) : (
+        <>
+          <main className="px-5 py-6 space-y-6">
+            <section className="space-y-3">
+              <div className="flex items-center gap-2">
+                <span className="material-symbols-outlined text-primary text-[20px]">
+                  event_note
+                </span>
+                <h2 className="text-xl font-semibold">행사 정보</h2>
+              </div>
+              <div className="bg-surface-container-lowest p-4 rounded-xl shadow-sm space-y-1">
+                <p className="text-base font-bold">{event.title}</p>
+                <p className="text-sm text-on-surface-variant">
+                  {event.location || "장소 미정"}
+                </p>
+                {event.description && (
+                  <p className="text-sm text-on-surface-variant whitespace-pre-line pt-2">
+                    {event.description}
+                  </p>
+                )}
+              </div>
+            </section>
+            <p className="text-sm text-on-surface-variant text-center pt-2">
+              별도 입력 없이 한 번의 클릭으로 사전 등록이 완료됩니다.
+            </p>
+          </main>
+          <div className="fixed bottom-0 left-0 w-full p-5 bg-surface/70 backdrop-blur-xl z-50">
+            <button
+              onClick={() => handleSubmit([])}
+              disabled={mutation.isPending || needsJoinPrompt}
+              className="w-full bg-gradient-to-br from-primary to-primary-container text-on-primary py-4 rounded-xl text-xl font-semibold shadow-lg active:scale-[0.98] transition-transform disabled:opacity-50"
+            >
+              {mutation.isPending ? "처리 중..." : "사전 등록하기"}
+            </button>
+          </div>
+        </>
+      )}
 
       {needsJoinPrompt && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center p-5 bg-on-surface/40 backdrop-blur-[2px]">


### PR DESCRIPTION
## Summary
- 운영진이 행사를 만들 때 \"참가자에게 정보를 받기\" 토글을 ON/OFF 선택 가능
- 토글 OFF 인 행사는 멤버 입장에서 폼이 보이지 않고 \"참여하기/사전 등록하기\" 버튼 하나만 노출. 클릭 한 번으로 등록 완료
- 백엔드 [BackEnd#41](https://github.com/Q-Check23/BackEnd/pull/41) 와 짝

## 변경 내용
### API 타입 / 매핑
- \`api/events.ts\`
  - \`CreateEventRequest\`, \`EventDetailResponse\`, \`EventDetail\` 에 \`collectRegistrationInfo: boolean\` 추가
  - \`mapEventDetail\` 은 \`response.collectRegistrationInfo !== false\` 로 평가 → 백엔드가 \`null\`/\`undefined\` 를 내려도 안전하게 ON(\`true\`) 으로 해석. 명시적 \`false\` 일 때만 OFF 분기 동작 (구버전 백엔드와의 forward 호환)

### CreateEvent (운영진)
- \`participants 정보 수집\` 섹션 위에 토글 스위치 추가 — 기본 ON
- 토글 OFF 면 필드 에디터 자체를 숨김 (사용자가 추가한 질문이 있어도 임시로 가려지고, 다시 ON 으로 돌리면 그대로 복원)
- submit 시 토글 OFF 면 \`formFields\` 를 빈 배열로 전송 → 백엔드도 폼 필드를 만들지 않음

### EditEvent (운영진)
- 토글을 read-only 로 노출. 현재 값 표시 + \"행사 생성 시에만 설정 가능합니다\" 안내. 운영진 의사결정대로 수정 단계에선 변경 불가

### Register / Checkin (멤버)
- \`event.collectRegistrationInfo === false\` 면 \`EventRegistrationForm\` 대신 \"행사 정보 요약 + 단일 버튼\" 화면 렌더
- 버튼은 \`handleSubmit([])\` 로 기존 mutation 호출 → 성공 토스트와 이후 흐름은 그대로 유지

## 배포 순서
**백엔드 PR #41 먼저 머지·배포** → 이 PR 머지. 반대로 가도 \`response.collectRegistrationInfo !== false\` 평가 덕분에 OFF 분기가 잘못 발동되진 않지만, 토글이 의미 있게 동작하려면 백엔드가 플래그를 저장·노출해야 함.

## Test plan
- [ ] 운영진 계정으로 토글 OFF 한 행사 생성 → 멤버 계정으로 사전등록 링크 진입 → 폼 없이 \"사전 등록하기\" 버튼만 보이는지 확인
- [ ] 토글 OFF 행사에서 멤버가 버튼 클릭 → 빈 답변으로 등록 + \"사전 등록이 완료되었어요\" 토스트 + \`/event-info\` 이동
- [ ] 토글 ON 행사는 기존과 동일한 폼 + 자동채움 동작 회귀 확인
- [ ] EditEvent 진입 시 토글이 disabled 상태로 보이는지, 현재 ON/OFF 값이 정확히 반영되는지
- [ ] QR 체크인 흐름에서 미등록자가 OFF 행사 링크로 진입 시에도 동일하게 \"참여하기\" 단일 버튼 + 토스트 동작 확인