### PR TITLE
fix: 행사 생성 버튼이 미완성 폼에서 조용히 무응답이던 문제 수정

### DIFF
--- a/src/pages/CreateEvent/CreateEvent.tsx
+++ b/src/pages/CreateEvent/CreateEvent.tsx
@@ -52,8 +52,10 @@ export default function CreateEvent() {
     );
   }
 
+  const isValid = title.trim().length > 0 && date.length > 0 && time.length > 0;
+
   function handleSubmit() {
-    if (!title.trim() || !date || !time) return;
+    if (!isValid) return;
 
     const startTime = `${date}T${time}${time.length === 5 ? ":00" : ""}`;
 
@@ -364,8 +366,8 @@ export default function CreateEvent() {
       <div className="fixed bottom-0 left-0 w-full p-5 bg-surface/70 backdrop-blur-xl z-50">
         <button
           onClick={handleSubmit}
-          disabled={mutation.isPending}
-          className="w-full bg-gradient-to-br from-primary to-primary-container text-on-primary py-4 rounded-xl text-xl font-semibold shadow-lg active:scale-[0.98] transition-transform disabled:opacity-50"
+          disabled={!isValid || mutation.isPending}
+          className="w-full bg-gradient-to-br from-primary to-primary-container text-on-primary py-4 rounded-xl text-xl font-semibold shadow-lg active:scale-[0.98] transition-transform disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {mutation.isPending ? "생성 중..." : "QR코드 생성하기"}
         </button>


### PR DESCRIPTION
## Summary
- 행사 만들기 페이지에서 \"QR코드 생성하기\" 버튼을 눌렀는데 아무 반응이 없던 문제 수정
- 제목/날짜/시간 중 하나라도 안 채워졌을 때 버튼이 시각적으로 비활성화되도록 변경

## 원인
[CreateEvent.tsx:55-56](https://github.com/Q-Check23/FrontEnd/blob/main/src/pages/CreateEvent/CreateEvent.tsx#L55-L56) 의 \`handleSubmit\` 이 \`if (!title.trim() || !date || !time) return;\` 로 조용히 종료. 그런데 버튼 disabled 는 \`mutation.isPending\` 만 보고 있어서 폼이 미완 상태여도 버튼은 정상색이고 클릭이 됨. 결과적으로:
- 누른 듯 보이지만 (active:scale-[0.98] 살짝 눌림)
- 토스트도 안 뜨고, 페이지 이동도 없음 → 사용자는 \"고장난 줄\" 느낌

[Login.jsx:225](https://github.com/Q-Check23/FrontEnd/blob/main/src/pages/Login/Login.jsx#L225), [EditEvent.tsx:212](https://github.com/Q-Check23/FrontEnd/blob/main/src/pages/EditEvent/EditEvent.tsx#L212) 는 둘 다 \`disabled={!isValid || ...}\` 패턴을 쓰는데 여기만 빠져 있던 일관성 문제기도 함.

## 변경 내용
- \`isValid\` = \`title.trim().length > 0 && date.length > 0 && time.length > 0\` 계산
- \`handleSubmit\` 의 안전 가드를 \`if (!isValid) return\` 으로 정리
- 버튼 \`disabled={!isValid || mutation.isPending}\`, \`disabled:cursor-not-allowed\` 추가로 커서까지 명확히

## Test plan
- [ ] /create-event 진입 후 아무 것도 입력 안 한 상태에서 버튼이 회색/투명도 50% 로 비활성화되는지 확인
- [ ] 제목만 입력, 또는 날짜만 입력 등 부분적으로 채운 상태에서도 버튼이 계속 비활성인지 확인
- [ ] 제목 + 날짜 + 시간 모두 채우면 버튼이 살아나고, 클릭하면 정상적으로 생성되는지 확인
- [ ] 생성 중일 때 \"생성 중...\" 텍스트로 바뀌면서 비활성이 유지되는지 확인