### PR TITLE
fix: 보호 경로 튕김 시 Discord OAuth 자동 트리거 + 휴대폰 자동채움 안내

### DIFF
--- a/src/components/EventRegistrationForm.tsx
+++ b/src/components/EventRegistrationForm.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useJoinClubViaEvent, useMyClubs, useMyProfile } from "../hooks";
 import { useToastStore } from "../stores/useToastStore";
 import type { EventDetail } from "../api/events";
 import type { MyProfile } from "../api/users";
+
+const PHONE_LABEL_REGEX = /전화|연락처|휴대폰|핸드폰|phone|mobile/i;
 
 interface EventRegistrationFormProps {
   event: EventDetail;
@@ -23,8 +25,7 @@ function guessProfileValue(
   profile: MyProfile,
 ): string | undefined {
   if (/이름|성함|실명|name/i.test(label)) return profile.realName || undefined;
-  if (/전화|연락처|휴대폰|핸드폰|phone|mobile/i.test(label))
-    return profile.phone || undefined;
+  if (PHONE_LABEL_REGEX.test(label)) return profile.phone || undefined;
   if (/이메일|메일|email/i.test(label)) return profile.email || undefined;
   return undefined;
 }
@@ -63,6 +64,14 @@ export default function EventRegistrationForm({
 
   const isMember = myClubs.some((club) => club.clubId === event.clubId);
   const needsJoinPrompt = !clubsLoading && !isMember && !joinedNow;
+
+  // 프로필에 전화번호가 비어있는 상태에서 폼에 전화번호 필드가 있으면 안내 표시.
+  // (PR #40/#43 머지 이전 가입자는 phone NULL — 한 번만 채워두면 다음부턴 자동채움)
+  const showProfilePhoneHint = useMemo(() => {
+    if (!profile) return false;
+    if (profile.phone && profile.phone.trim().length > 0) return false;
+    return event.formFields.some((f) => PHONE_LABEL_REGEX.test(f.label));
+  }, [profile, event.formFields]);
 
   function handleConfirmJoin() {
     joinMutation.mutate(event.eventId, {
@@ -123,6 +132,23 @@ export default function EventRegistrationForm({
             </span>
             <h2 className="text-xl font-semibold">참가자 정보</h2>
           </div>
+          {showProfilePhoneHint && (
+            <button
+              type="button"
+              onClick={() => navigate("/profile/settings")}
+              className="w-full bg-primary/5 border border-primary/20 rounded-xl p-3 flex items-start gap-2 text-left active:scale-[0.99] transition-transform"
+            >
+              <span className="material-symbols-outlined text-primary text-[18px] mt-0.5 shrink-0">
+                lightbulb
+              </span>
+              <span className="text-xs text-on-surface flex-1">
+                프로필에 휴대폰 번호를 등록해두면 다음부턴 자동으로 채워져요.{" "}
+                <span className="text-primary font-semibold underline">
+                  지금 등록하기
+                </span>
+              </span>
+            </button>
+          )}
           <div className="space-y-3">
             {event.formFields.map((field) => (
               <div

--- a/src/lib/authRedirect.ts
+++ b/src/lib/authRedirect.ts
@@ -1,4 +1,7 @@
 const AUTH_NEXT_STORAGE_KEY = "qcheck:auth-next";
+// 보호 경로에서 튕겨 자동 재인증을 한 번 시도했음을 표시 — Discord OAuth 에러로 다시
+// /login-landing 에 떨어졌을 때 무한 redirect 루프를 막기 위한 가드.
+const AUTH_AUTO_ATTEMPTED_KEY = "qcheck:auth-auto-attempted";
 
 export function setAuthNext(path: string) {
   if (!path || path.startsWith("/landing") || path.startsWith("/login")) {
@@ -7,10 +10,27 @@ export function setAuthNext(path: string) {
   sessionStorage.setItem(AUTH_NEXT_STORAGE_KEY, path);
 }
 
+export function peekAuthNext(): string | null {
+  return sessionStorage.getItem(AUTH_NEXT_STORAGE_KEY);
+}
+
 export function consumeAuthNext(): string | null {
   const next = sessionStorage.getItem(AUTH_NEXT_STORAGE_KEY);
   if (next) {
     sessionStorage.removeItem(AUTH_NEXT_STORAGE_KEY);
   }
   return next;
+}
+
+/** 한 세션에서 자동 OAuth 재시도를 했는지 여부. true 면 더는 자동 시도하지 않는다. */
+export function hasAttemptedAutoRelogin(): boolean {
+  return sessionStorage.getItem(AUTH_AUTO_ATTEMPTED_KEY) === "1";
+}
+
+export function markAutoReloginAttempted() {
+  sessionStorage.setItem(AUTH_AUTO_ATTEMPTED_KEY, "1");
+}
+
+export function clearAutoReloginAttempt() {
+  sessionStorage.removeItem(AUTH_AUTO_ATTEMPTED_KEY);
 }

--- a/src/pages/AuthCallback/AuthCallback.tsx
+++ b/src/pages/AuthCallback/AuthCallback.tsx
@@ -2,7 +2,10 @@ import { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useUserStore } from "../../stores/useUserStore";
 import { useToastStore } from "../../stores/useToastStore";
-import { consumeAuthNext } from "../../lib/authRedirect";
+import {
+  clearAutoReloginAttempt,
+  consumeAuthNext,
+} from "../../lib/authRedirect";
 
 const SIGNUP_TOKEN_STORAGE_KEY = "qcheck:signup-token";
 
@@ -36,6 +39,9 @@ export default function AuthCallback() {
     }
 
     setAccessToken(token);
+    // 자동 재인증이 성공으로 끝났으니 가드 플래그 해제 — 다음 보호경로 튕김 시
+    // 또 한 번 자동 시도가 가능하도록 정상 상태로 복귀시킨다.
+    clearAutoReloginAttempt();
     const next = consumeAuthNext();
     navigate(next ?? "/home", { replace: true });
   }, [navigate, pushToast, searchParams, setAccessToken]);

--- a/src/pages/Landing/Login-Landing.jsx
+++ b/src/pages/Landing/Login-Landing.jsx
@@ -1,8 +1,41 @@
+import { useEffect, useState } from "react";
 import logo from "../../assets/png/logo2.png";
 import discord_logo from "../../assets/png/discord.png";
 import { redirectToDiscordLogin } from "../../api/auth";
+import {
+  peekAuthNext,
+  hasAttemptedAutoRelogin,
+  markAutoReloginAttempted,
+} from "../../lib/authRedirect";
 
 export default function Login_Landing() {
+  // 보호 경로에서 인증 실패로 튕겨 들어온 경우 (authNext 가 세션에 저장돼 있음),
+  // 디스코드 OAuth 를 한 번 자동 트리거해서 디스코드 세션이 살아있다면 사용자가
+  // 버튼을 누르지 않아도 원래 가려던 곳으로 복귀하도록 한다.
+  // 한 세션에서 한 번만 시도 — OAuth 가 에러로 실패해 다시 떨어졌을 때
+  // 무한 redirect 루프를 막는다.
+  const [redirecting] = useState(() => {
+    if (peekAuthNext() && !hasAttemptedAutoRelogin()) {
+      markAutoReloginAttempted();
+      return true;
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    if (redirecting) {
+      redirectToDiscordLogin();
+    }
+  }, [redirecting]);
+
+  if (redirecting) {
+    return (
+      <div className="w-full h-full flex flex-col items-center justify-center">
+        <p className="text-sm text-on-surface-variant">로그인 중...</p>
+      </div>
+    );
+  }
+
   return (
     <div className="w-full h-full flex flex-col items-center justify-center space-y-3">
       <img src={logo} alt="Q-Check 로고" className="w-38 h-auto" />


### PR DESCRIPTION
## Summary
두 가지 관련 이슈를 같이 픽스:

1. **QR 스캔 자동로그인 실패** — \`SameSite=Lax\` 적용([BackEnd#39](https://github.com/Q-Check23/BackEnd/pull/39))으로 same-origin 케이스는 해결됐지만 in-app 브라우저/만료 쿠키/다른 브라우저 컨텍스트 등에선 여전히 \`/auth/refresh\` 가 401 로 떨어져 \`/landing\` → \`/login-landing\` 로 튕기고, 사용자가 디스코드 버튼을 직접 눌러야 했음. 디스코드 세션이 살아있으면 한 번의 OAuth redirect 로 충분한데도 수동 클릭이 필요했던 마찰 제거
2. **\"연락처 (전화번호)\" 자동채움이 안 채워짐** — 자동채움 로직([EventRegistrationForm.tsx:21-30](https://github.com/Q-Check23/FrontEnd/blob/main/src/components/EventRegistrationForm.tsx#L21))은 정상 동작하지만 [BackEnd#40](https://github.com/Q-Check23/BackEnd/pull/40)/[FrontEnd#43](https://github.com/Q-Check23/FrontEnd/pull/43) 머지 이전 가입자는 \`User.phone\` 이 NULL 이라 채울 값이 없음. 프로필 설정에서 한 번만 채우면 해결되는데 그 사실을 사용자가 모름

## 변경 내용

### Issue 1 — 자동 재인증
- \`authRedirect.ts\`: \`peekAuthNext\`, \`hasAttemptedAutoRelogin\`, \`markAutoReloginAttempted\`, \`clearAutoReloginAttempt\` 추가. 무한 redirect 루프 방지용 가드 도입
- \`Login-Landing.jsx\`: 마운트 시점에 \`authNext\` 가 있고 자동 시도를 아직 안 한 세션이면 \`redirectToDiscordLogin()\` 을 즉시 호출. 사용자에겐 \"로그인 중...\" 짧은 안내 표시
- \`AuthCallback.tsx\`: 정상 로그인 성공 시 \`clearAutoReloginAttempt()\` 로 가드 해제 → 다음 보호경로 튕김 시 다시 자동 시도 가능
- 루프 방지: OAuth 가 에러로 실패해 \`/login-landing\` 에 다시 떨어져도 \`hasAttemptedAutoRelogin()\` 이 true 라 자동 재시도하지 않음. 사용자는 디스코드 버튼을 수동으로 누름

### Issue 2 — 휴대폰 자동채움 안내
- \`EventRegistrationForm.tsx\`: \`PHONE_LABEL_REGEX\` 를 상수로 끌어올리고 \`showProfilePhoneHint\` 메모로 \"폼에 휴대폰 매칭 필드가 있는데 profile.phone 이 비어있는 상태\" 를 감지
- 폼 헤더 \"참가자 정보\" 아래에 안내 배너 표시 — \"프로필에 휴대폰 번호를 등록해두면 다음부턴 자동으로 채워져요\" + 클릭 시 \`/profile/settings\` 로 이동

## 시나리오별 동작
| 케이스 | 이전 | 이후 |
|---|---|---|
| 같은 브라우저 쿠키 살아있음 | refresh 성공 → 곧바로 진입 | 동일 |
| 쿠키 만료/in-app 브라우저 + 디스코드 세션 살아있음 | landing → 사용자가 버튼 클릭 → OAuth → 복귀 | landing → 자동 OAuth → 즉시 복귀 |
| 쿠키 만료 + 디스코드 세션도 만료 | landing → 버튼 클릭 → Discord 로그인 → 복귀 | landing → 자동 OAuth → Discord 로그인 화면 → 복귀 |
| OAuth 자체가 에러 (state 등) | 에러 토스트 → landing | 에러 토스트 → landing (자동 시도 차단, 버튼 수동) |
| 첫 진입 (보호경로 거치지 않음) | 버튼 보임 | 동일 (authNext 없으니 자동 트리거 안 됨) |

## Test plan
- [ ] 로그인 상태로 보호 경로 직접 진입 → 그대로 렌더링되는지 확인 (회귀)
- [ ] 로그아웃 후 \`/checkin?eventId=X\` 직접 진입 → /landing 거쳐 자동 OAuth 트리거 → /checkin 으로 복귀 확인
- [ ] 자동 트리거 후 OAuth 에러 시 무한 루프 없이 \`/login-landing\` 정상 표시
- [ ] 로그인 → 로그아웃 → 다른 보호 경로 진입 → 다시 자동 트리거 동작 (가드 해제 확인)
- [ ] 휴대폰 NULL 인 기존 계정으로 사전등록 페이지 진입 → 안내 배너 노출
- [ ] 배너 클릭 → \`/profile/settings\` 이동, 휴대폰 등록 후 등록 페이지 재진입 시 자동채움 + 배너 사라짐