### PR TITLE
feat: 자동 재인증 트리거 시 silent=true 로 Discord 동의 화면 건너뛰기

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -28,8 +28,17 @@ export function checkUsernameAvailability(username: string) {
   });
 }
 
-export function redirectToDiscordLogin() {
-  window.location.assign(`${API_ORIGIN}/api/auth/login`);
+/**
+ * Discord OAuth 로그인 페이지로 redirect 한다.
+ * silent=true 면 백엔드가 prompt=none 으로 Discord 에 요청 → 이미 인가된
+ * 사용자는 동의 화면 없이 곧바로 콜백으로 돌아온다. 인가 안 된 사용자의
+ * 경우 백엔드가 자동으로 일반 흐름(동의 화면) 으로 폴백한다.
+ */
+export function redirectToDiscordLogin(silent: boolean = false) {
+  const url = silent
+    ? `${API_ORIGIN}/api/auth/login?silent=true`
+    : `${API_ORIGIN}/api/auth/login`;
+  window.location.assign(url);
 }
 
 export function signup(payload: SignupRequest, signupToken: string) {

--- a/src/pages/Landing/Login-Landing.jsx
+++ b/src/pages/Landing/Login-Landing.jsx
@@ -24,7 +24,9 @@ export default function Login_Landing() {
 
   useEffect(() => {
     if (redirecting) {
-      redirectToDiscordLogin();
+      // 자동 재인증 — prompt=none 으로 보내 디스코드 동의 화면을 건너뛴다.
+      // 인가 안 된 사용자의 경우 백엔드가 자동으로 일반 흐름으로 폴백.
+      redirectToDiscordLogin(true);
     }
   }, [redirecting]);
 


### PR DESCRIPTION
## Summary
QR 스캔 후 자동 재인증되는 흐름에서 Discord 동의 화면을 건너뛰도록 \`redirectToDiscordLogin(true)\` 옵션 추가.

- \`redirectToDiscordLogin(silent?: boolean)\` 시그니처에 silent 플래그 추가
- silent=true 면 \`/api/auth/login?silent=true\` 로 호출 → 백엔드가 \`prompt=none\` 으로 Discord 요청
- 이미 인가된 사용자는 동의 화면 없이 곧바로 콜백 복귀 (사실상 자동로그인)
- /login-landing 의 자동 트리거에만 silent=true 적용. 수동 디스코드 버튼 클릭은 기존과 동일 (가입자 보호)

## 백엔드 짝
[BackEnd#42](https://github.com/Q-Check23/BackEnd/pull/42)

## 배포 순서
**백엔드 먼저 머지·배포** → 이 PR 머지. 백엔드 미배포 상태에서 프론트가 silent=true 를 보내면 백엔드는 알 수 없는 파라미터로 무시하고 기존 일반 흐름을 타므로 안전.

## 시나리오별 동작
| 케이스 | 이전 | 이후 |
|---|---|---|
| 보호 경로 튕김 → 자동 트리거 → Discord 앱 인가됨 | landing → 디스코드 동의 화면 → 복귀 | landing → \"로그인 중...\" → 곧바로 복귀 |
| 보호 경로 튕김 → 자동 트리거 → Discord 인가 안 됨 | landing → 디스코드 동의 화면 → 복귀 | landing → \"로그인 중...\" → 백엔드 자동 폴백 → 디스코드 동의 화면 → 복귀 |
| 수동 디스코드 버튼 클릭 (첫 가입자) | 동의 화면 | 동일 |
| 수동 디스코드 버튼 클릭 (기존 회원) | 동의 화면 | 동일 (수동은 보안 위해 동의 화면 유지) |

## Test plan
- [ ] 백엔드 머지·배포 후 디스코드 로그인 한 폰에서 로그아웃 → \`/checkin\` 진입 → 동의 화면 없이 복귀 확인
- [ ] Discord 설정에서 Q-Check 인가 취소 → /checkin 진입 → 자동 폴백으로 동의 화면 한 번 표시 → 복귀
- [ ] 수동 디스코드 버튼 클릭 시 동의 화면 그대로 표시 (회귀)