### PR TITLE
fix: 아이디 중복확인 토스트가 부정적으로 보이던 문제 — success/error variant 적용

### DIFF
--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -77,7 +77,7 @@ export default function Login() {
       if (response.available) {
         setUsernameStatus("available");
         setUsernameMessage("사용 가능한 아이디입니다.");
-        pushToast("아이디를 사용할 수 있습니다.");
+        pushToast("아이디를 사용할 수 있어요", "success");
         return;
       }
 
@@ -88,7 +88,7 @@ export default function Login() {
         error instanceof Error ? error.message : "아이디 확인에 실패했습니다.";
       setUsernameStatus("error");
       setUsernameMessage(message);
-      pushToast(message);
+      pushToast(message, "error");
     } finally {
       setIsCheckingUsername(false);
     }


### PR DESCRIPTION
## Summary
회원가입 폼의 아이디 중복확인 결과 토스트가 기본 \`info\` variant(어두운 배경)로 떠서 \"사용 가능한 아이디입니다\" 라는 메시지조차 도리어 \"불가능\" 으로 읽히던 UX 문제 수정.

## 변경 내용
[Login.jsx:80](https://github.com/Q-Check23/FrontEnd/blob/main/src/pages/Login/Login.jsx#L80)
- \`pushToast(\"아이디를 사용할 수 있습니다.\")\` → \`pushToast(\"아이디를 사용할 수 있어요\", \"success\")\` (에메랄드 + check_circle, 캐주얼한 메시지)
- 아이디 확인 네트워크 에러 토스트도 \`error\` variant (레드 + error 아이콘) 명시
- \"이미 사용 중\" 케이스는 기존대로 인라인 빨간 메시지만 — 토스트 중복으로 시끄러워지지 않게 유지

## 추가 확인 (별도 픽스 아님)
사용자 보고: \"QR 체크인 흐름에서 사전등록 폼 → 제출 → 체크인 완료 토스트가 안 보인다\"
→ 코드 확인 결과 [Checkin.tsx:52](https://github.com/Q-Check23/FrontEnd/blob/main/src/pages/Checkin/Checkin.tsx#L52) 에 \`pushToast(\"참여가 완료되었어요\", \"success\")\` 정상 호출되고 있음. ToastContainer 는 Routes 바깥이라 navigate 후에도 유지. 만약 실제로 안 뜬다면 \`selfCheckIn\` 자체가 409 외 에러로 실패하는 케이스일 가능성 — 그 경우 다른 에러 토스트가 뜨는 게 정상.

## Test plan
- [ ] 사용 가능한 아이디 입력 → \"중복 확인\" 클릭 → 에메랄드 success 토스트 \"아이디를 사용할 수 있어요\" 확인
- [ ] 이미 가입된 아이디 입력 → \"중복 확인\" 클릭 → 토스트 없이 인라인 빨간 메시지만 (회귀)
- [ ] 네트워크 끊고 \"중복 확인\" → 레드 error 토스트