### PR TITLE
fix: 행사 생성/수정 폼의 '시작 날짜' '시작 시간' 컬럼 폭이 안 맞던 문제

### DIFF
--- a/src/pages/CreateEvent/CreateEvent.tsx
+++ b/src/pages/CreateEvent/CreateEvent.tsx
@@ -123,7 +123,7 @@ export default function CreateEvent() {
               />
             </div>
             <div className="grid grid-cols-2 gap-3">
-              <div>
+              <div className="min-w-0">
                 <label className="text-xs font-semibold text-on-surface-variant block mb-2">
                   시작 날짜
                 </label>
@@ -131,10 +131,10 @@ export default function CreateEvent() {
                   type="date"
                   value={date}
                   onChange={(e) => setDate(e.target.value)}
-                  className="w-full bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
+                  className="w-full min-w-0 bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
                 />
               </div>
-              <div>
+              <div className="min-w-0">
                 <label className="text-xs font-semibold text-on-surface-variant block mb-2">
                   시작 시간
                 </label>
@@ -142,7 +142,7 @@ export default function CreateEvent() {
                   type="time"
                   value={time}
                   onChange={(e) => setTime(e.target.value)}
-                  className="w-full bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
+                  className="w-full min-w-0 bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
                 />
               </div>
             </div>

--- a/src/pages/EditEvent/EditEvent.tsx
+++ b/src/pages/EditEvent/EditEvent.tsx
@@ -142,7 +142,7 @@ export default function EditEvent() {
               />
             </div>
             <div className="grid grid-cols-2 gap-3">
-              <div>
+              <div className="min-w-0">
                 <label className="text-xs font-semibold text-on-surface-variant block mb-2">
                   시작 날짜
                 </label>
@@ -150,10 +150,10 @@ export default function EditEvent() {
                   type="date"
                   value={date}
                   onChange={(e) => setDate(e.target.value)}
-                  className="w-full bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
+                  className="w-full min-w-0 bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
                 />
               </div>
-              <div>
+              <div className="min-w-0">
                 <label className="text-xs font-semibold text-on-surface-variant block mb-2">
                   시작 시간
                 </label>
@@ -161,7 +161,7 @@ export default function EditEvent() {
                   type="time"
                   value={time}
                   onChange={(e) => setTime(e.target.value)}
-                  className="w-full bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
+                  className="w-full min-w-0 bg-surface-container-low border-none rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
모바일에서 행사 생성/수정 폼의 \"시작 날짜\" 와 \"시작 시간\" 입력칸 폭이 50:50 으로 안 나뉘고 한쪽이 잘리거나 라벨이 어긋나 보이던 문제 수정.

## 원인
\`grid-cols-2\` 의 컬럼이 기본 \`minmax(auto, 1fr)\` — \`auto\` 최소값이 자식의 intrinsic(max-content) 폭이라, iOS Safari 의 네이티브 \`input[type=date]\` / \`input[type=time]\` 의 고유 최소폭이 컬럼 할당폭보다 클 때 grid 가 overflow. 결과적으로 한쪽 컬럼이 더 차지하면서 \`w-full\` 인 인풋이 어긋나 보임.

동일 패턴을 [BottomSheet 의 기간 선택 종료일](https://github.com/Q-Check23/FrontEnd/pull/41) 에서 이미 한 번 잡은 적 있고, 같은 fix 가 여기에도 필요.

## 변경 내용
- [CreateEvent.tsx:125-148](https://github.com/Q-Check23/FrontEnd/blob/main/src/pages/CreateEvent/CreateEvent.tsx#L125-L148): 그리드 셀과 input 양쪽에 \`min-w-0\` 추가
- [EditEvent.tsx:144-167](https://github.com/Q-Check23/FrontEnd/blob/main/src/pages/EditEvent/EditEvent.tsx#L144-L167): 동일 패턴 같이 수정

\`min-w-0\` 으로 컬럼이 \`minmax(0, 1fr)\` 처럼 동작 → \`w-full\` 인 input 이 정상적으로 컬럼 폭에 맞춰 줄어들면서 50:50 으로 균형 잡힘.

## Test plan
- [ ] iPhone Safari 에서 /create-event 진입 → 시작 날짜/시간 두 인풋이 동일 폭으로 50:50 표시되는지 확인
- [ ] 값 채우고 다시 봐도 어긋남 없는지 확인
- [ ] /edit-event 도 동일 확인
- [ ] Android Chrome 에서도 회귀 확인